### PR TITLE
eliminating problem with calling emitted status twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Observable<List<ScanResult>> observeWifiAccessPoints(final Context context)
 
 ```java
 public enum ConnectivityStatus {
+  UNDEFINED("undefined"),
   WIFI_CONNECTED("connected to WiFi"),
   MOBILE_CONNECTED("connected to mobile network"),
   OFFLINE("offline");

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/ConnectivityStatus.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/ConnectivityStatus.java
@@ -18,6 +18,7 @@ package com.github.pwittchen.reactivenetwork.library;
 import rx.functions.Func1;
 
 public enum ConnectivityStatus {
+  UNDEFINED("undefined"),
   WIFI_CONNECTED("connected to WiFi"),
   MOBILE_CONNECTED("connected to mobile network"),
   OFFLINE("offline");


### PR DESCRIPTION
Solves #3.

For some reason status is emitted twice when going off-line, so we need to check if status is the same, before emission.
Moreover, I've removed filter `WIFI_STATE_CHANGED_ACTION` from `BroadcastReceiver`, because we want to observe connectivity status (when device is connected to WiFi) not the situation, when user turns on or off WiFi. We can create another observable for that thing in the future.