### PR TITLE
Fix crash when pre-lollipop receiver is already unregistered

### DIFF
--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/network/observing/strategy/PreLollipopNetworkObservingStrategy.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/network/observing/strategy/PreLollipopNetworkObservingStrategy.java
@@ -51,7 +51,12 @@ public class PreLollipopNetworkObservingStrategy implements NetworkObservingStra
 
         subscriber.add(unsubscribeInUiThread(new Action0() {
           @Override public void call() {
-            context.unregisterReceiver(receiver);
+            //Catch case where the receiver is already unregistered
+            try {
+              context.unregisterReceiver(receiver);
+            } catch (Exception e) {
+              // ignore exception
+            }
           }
         }));
       }


### PR DESCRIPTION
See http://stackoverflow.com/a/3568906/818821

Fixes #87 