### PR TITLE
Add check internet connectivity immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ Usage
 Library has the following RxJava Observables available in the public API:
 
 ```java
-Observable<Connectivity> observeNetworkConnectivity(final Context context)
-Observable<Connectivity> observeNetworkConnectivity(final Context context, final NetworkObservingStrategy strategy)
+Observable<Connectivity> observeNetworkConnectivity(Context context)
+Observable<Connectivity> observeNetworkConnectivity(Context context, NetworkObservingStrategy strategy)
 Observable<Boolean> observeInternetConnectivity()
-Observable<Boolean> observeInternetConnectivity(final int interval, final String host, final int port, final int timeout)
+Observable<Boolean> observeInternetConnectivityImmediately()
+Observable<Boolean> observeInternetConnectivity(int intervalInMs, String host, int port, int timeout)
+Observable<Boolean> observeInternetConnectivity(int initialIntervalInMs, int intervalInMs, String host, int port, int timeout)
 ```
 
 **Please note**: Due to memory leak in `WifiManager` reported
@@ -70,7 +72,7 @@ ReactiveNetwork.observeNetworkConnectivity(context)
 
 When `Connectivity` changes, subscriber will be notified. `Connectivity` can change its state or type.
 
-We can react on a concrete state, states, type or types changes with the `filter(...)` method from RxJava, `hasState(final NetworkInfo.State... states)` and `hasType(final int... types)` methods located in `Connectivity` class.
+We can react on a concrete state, states, type or types changes with the `filter(...)` method from RxJava, `hasState(NetworkInfo.State... states)` and `hasType(int... types)` methods located in `Connectivity` class.
 
 ```java
 ReactiveNetwork.observeNetworkConnectivity(context)
@@ -91,7 +93,7 @@ ReactiveNetwork.observeNetworkConnectivity(context)
 You can also use method:
 
 ```java
-Observable<Connectivity> observeNetworkConnectivity(final Context context, final NetworkObservingStrategy strategy)
+Observable<Connectivity> observeNetworkConnectivity(Context context, NetworkObservingStrategy strategy)
 ```
 
 This method allows you to apply your own network observing strategy and is used by the library under the hood to determine appropriate strategy depending on the version of Android system.
@@ -114,8 +116,8 @@ boolean isDefault()
 String toString()
 
 // helper methods for filter(...) method from RxJava
-Func1<Connectivity, Boolean> hasState(final NetworkInfo.State... states)
-Func1<Connectivity, Boolean> hasType(final int... types)
+Func1<Connectivity, Boolean> hasState(NetworkInfo.State... states)
+Func1<Connectivity, Boolean> hasType(int... types)
 ```
 
 ### Observing Internet connectivity
@@ -137,10 +139,16 @@ An `Observable` will return `true` to the subscription if device is connected to
 
 **Please note**: This method is less efficient than `observeNetworkConnectivity(context)` method, because it opens socket connection with remote host (default is www.google.com) every two seconds with two seconds of timeout and consumes data transfer. Use this method if you really need it. Optionally, you can unsubscribe subcription right after you get notification that Internet is available and do the work you want in order to decrease network calls.
 
+If you want to check Internet connectivity _as soon as possible_, you can use the following method:
+
+```java
+Observable<Boolean> observeInternetConnectivityImmediately()
+```
+
 If you want to specify your own custom details for checking Internet connectivity, you can use the following method:
 
 ```java
-Observable<Boolean> observeInternetConnectivity(final int interval, final String host, final int port, final int timeout)
+Observable<Boolean> observeInternetConnectivity(int interval, String host, int port, int timeout)
 ```
 
 It allows you to specify custom interval of checking connectivity in milliseconds, host, port and connection timeout in milliseconds.

--- a/library/src/androidTest/java/com/github/pwittchen/reactivenetwork/library/ReactiveNetworkTest.java
+++ b/library/src/androidTest/java/com/github/pwittchen/reactivenetwork/library/ReactiveNetworkTest.java
@@ -20,8 +20,11 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import com.github.pwittchen.reactivenetwork.library.network.observing.NetworkObservingStrategy;
 import com.github.pwittchen.reactivenetwork.library.network.observing.strategy.LollipopNetworkObservingStrategy;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import rx.Observable;
 import rx.functions.Action1;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -32,6 +35,7 @@ import static com.google.common.truth.Truth.assertThat;
   private static final int TEST_VALID_PORT = 80;
   private static final int TEST_VALID_TIMEOUT = 1000;
   private static final int TEST_VALID_INTERVAL = 1000;
+  public static final int TEST_VALID_INITIAL_INTERVAL = 1000;
 
   @Test public void testReactiveNetworkObjectShouldNotBeNull() {
     // given
@@ -42,6 +46,90 @@ import static com.google.common.truth.Truth.assertThat;
 
     // then
     assertThat(reactiveNetwork).isNotNull();
+  }
+
+  @Test
+  public void observeNetworkConnectivityShouldNotBeNull() {
+    // given
+    Context context = InstrumentationRegistry.getTargetContext();
+
+    // when
+    Observable<Connectivity> observable;
+    observable = ReactiveNetwork.observeNetworkConnectivity(context);
+
+    // then
+    assertThat(observable).isNotNull();
+  }
+
+  @Test
+  public void observeNetworkConnectivityWithStrategyShouldNotBeNull() {
+    // given
+    Context context = InstrumentationRegistry.getTargetContext();
+    NetworkObservingStrategy strategy = new LollipopNetworkObservingStrategy();
+
+    // when
+    Observable<Connectivity> observable;
+    observable = ReactiveNetwork.observeNetworkConnectivity(context, strategy);
+
+    // then
+    assertThat(observable).isNotNull();
+  }
+
+  @Test
+  public void observeInternetConnectivityDefaultShouldNotBeNull() {
+    // given
+    Observable<Boolean> observable;
+
+    // when
+    observable = ReactiveNetwork.observeInternetConnectivity();
+
+    // then
+    assertThat(observable).isNotNull();
+  }
+
+  @Test
+  public void observeInternetConnectivityImmediatelyShouldNotBeNull() {
+    // given
+    Observable<Boolean> observable;
+
+    // when
+    observable = ReactiveNetwork.observeInternetConnectivityImmediately();
+
+    // then
+    assertThat(observable).isNotNull();
+  }
+
+  @Test
+  public void observeInternetConnectivityWithConfigurationShouldNotBeNull() {
+    // given
+    Observable<Boolean> observable;
+    int interval = TEST_VALID_INTERVAL;
+    String host = TEST_VALID_HOST;
+    int port = TEST_VALID_PORT;
+    int timeout = TEST_VALID_TIMEOUT;
+
+    // when
+    observable = ReactiveNetwork.observeInternetConnectivity(interval, host, port, timeout);
+
+    // then
+    assertThat(observable).isNotNull();
+  }
+
+  @Test
+  public void observeInternetConnectivityWithFullConfigurationShouldNotBeNull() {
+    // given
+    Observable<Boolean> observable;
+    int initialInterval = TEST_VALID_INITIAL_INTERVAL;
+    int interval = TEST_VALID_INTERVAL;
+    String host = TEST_VALID_HOST;
+    int port = TEST_VALID_PORT;
+    int timeout = TEST_VALID_TIMEOUT;
+
+    // when
+    observable = ReactiveNetwork.observeInternetConnectivity(initialInterval, interval, host, port, timeout);
+
+    // then
+    assertThat(observable).isNotNull();
   }
 
   @Test public void observeNetworkConnectivityShouldBeDefaultIfEmpty() {
@@ -194,6 +282,39 @@ import static com.google.common.truth.Truth.assertThat;
 
     // when
     ReactiveNetwork.observeInternetConnectivity(interval, host, port, timeout);
+
+    // then
+    // an exception is thrown
+  }
+
+  @Test
+  public void observeInternetConnectivityShouldNotThrowAnExceptionForZeroInitialInterval() {
+    // given
+    Observable<Boolean> observable;
+    int initialInterval = 0;
+    int interval = TEST_VALID_INTERVAL;
+    String host = TEST_VALID_HOST;
+    int port = TEST_VALID_PORT;
+    int timeout = TEST_VALID_TIMEOUT;
+
+    // when
+    observable = ReactiveNetwork.observeInternetConnectivity(initialInterval, interval, host, port, timeout);
+
+    // then
+    assertThat(observable).isNotNull();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void observeInternetConnectivityShouldThrowAnExceptionForNegativeInitialInterval() {
+    // given
+    int initialInterval = -1;
+    int interval = TEST_VALID_INTERVAL;
+    String host = TEST_VALID_HOST;
+    int port = TEST_VALID_PORT;
+    int timeout = TEST_VALID_TIMEOUT;
+
+    // when
+    ReactiveNetwork.observeInternetConnectivity(initialInterval, interval, host, port, timeout);
 
     // then
     // an exception is thrown

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/Connectivity.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/Connectivity.java
@@ -133,7 +133,7 @@ public class Connectivity {
    * @return boolean true if connectivity is default and false if not
    */
   public boolean isDefault() {
-    return getState() == DEFAULT_STATE && getType() == DEFAULT_TYPE && getName() == DEFAULT_NAME;
+    return getState() == DEFAULT_STATE && getType() == DEFAULT_TYPE && getName().equals(DEFAULT_NAME);
   }
 
   @Override public String toString() {

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/network/observing/strategy/PreLollipopNetworkObservingStrategy.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/network/observing/strategy/PreLollipopNetworkObservingStrategy.java
@@ -51,7 +51,12 @@ public class PreLollipopNetworkObservingStrategy implements NetworkObservingStra
 
         subscriber.add(unsubscribeInUiThread(new Action0() {
           @Override public void call() {
-            context.unregisterReceiver(receiver);
+            //Catch case where the receiver is already unregistered
+            try {
+              context.unregisterReceiver(receiver);
+            } catch (Exception e) {
+              // ignore exception
+            }
           }
         }));
       }


### PR DESCRIPTION
This is so that the app checks for connection immediately instead of delaying the check. See http://reactivex.io/RxJava/javadoc/rx/Observable.html#interval(long,%20long,%20java.util.concurrent.TimeUnit)