### PR TITLE
closing socket during observing Internet connectivity; delegating obs…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Observable<Connectivity> observeNetworkConnectivity(Context context, NetworkObse
 Observable<Boolean> observeInternetConnectivity()
 Observable<Boolean> observeInternetConnectivity(int intervalInMs, String host, int port, int timeout)
 Observable<Boolean> observeInternetConnectivity(int initialIntervalInMs, int intervalInMs, String host, int port, int timeout)
+Observable<Boolean> observeInternetConnectivity(final int initialIntervalInMs, final int intervalInMs, final String host, final int port, final int timeoutInMs, final SocketErrorHandler socketErrorHandler)
+Observable<Boolean> observeInternetConnectivity(final InternetObservingStrategy strategy, final int initialIntervalInMs, final int intervalInMs, final String host, final int port, final int timeoutInMs, final SocketErrorHandler socketErrorHandler)
 ```
 
 **Please note**: Due to memory leak in `WifiManager` reported

--- a/library/src/androidTest/java/com/github/pwittchen/reactivenetwork/library/ReactiveNetworkTest.java
+++ b/library/src/androidTest/java/com/github/pwittchen/reactivenetwork/library/ReactiveNetworkTest.java
@@ -18,12 +18,13 @@ package com.github.pwittchen.reactivenetwork.library;
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import com.github.pwittchen.reactivenetwork.library.internet.observing.InternetObservingStrategy;
+import com.github.pwittchen.reactivenetwork.library.internet.socket.DefaultSocketErrorHandler;
+import com.github.pwittchen.reactivenetwork.library.internet.socket.SocketErrorHandler;
 import com.github.pwittchen.reactivenetwork.library.network.observing.NetworkObservingStrategy;
 import com.github.pwittchen.reactivenetwork.library.network.observing.strategy.LollipopNetworkObservingStrategy;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import rx.Observable;
 import rx.functions.Action1;
 
@@ -48,8 +49,7 @@ import static com.google.common.truth.Truth.assertThat;
     assertThat(reactiveNetwork).isNotNull();
   }
 
-  @Test
-  public void observeNetworkConnectivityShouldNotBeNull() {
+  @Test public void observeNetworkConnectivityShouldNotBeNull() {
     // given
     Context context = InstrumentationRegistry.getTargetContext();
 
@@ -61,8 +61,7 @@ import static com.google.common.truth.Truth.assertThat;
     assertThat(observable).isNotNull();
   }
 
-  @Test
-  public void observeNetworkConnectivityWithStrategyShouldNotBeNull() {
+  @Test public void observeNetworkConnectivityWithStrategyShouldNotBeNull() {
     // given
     Context context = InstrumentationRegistry.getTargetContext();
     NetworkObservingStrategy strategy = new LollipopNetworkObservingStrategy();
@@ -75,8 +74,7 @@ import static com.google.common.truth.Truth.assertThat;
     assertThat(observable).isNotNull();
   }
 
-  @Test
-  public void observeInternetConnectivityDefaultShouldNotBeNull() {
+  @Test public void observeInternetConnectivityDefaultShouldNotBeNull() {
     // given
     Observable<Boolean> observable;
 
@@ -87,8 +85,7 @@ import static com.google.common.truth.Truth.assertThat;
     assertThat(observable).isNotNull();
   }
 
-  @Test
-  public void observeInternetConnectivityWithConfigurationShouldNotBeNull() {
+  @Test public void observeInternetConnectivityWithConfigurationShouldNotBeNull() {
     // given
     Observable<Boolean> observable;
     int interval = TEST_VALID_INTERVAL;
@@ -103,8 +100,7 @@ import static com.google.common.truth.Truth.assertThat;
     assertThat(observable).isNotNull();
   }
 
-  @Test
-  public void observeInternetConnectivityWithFullConfigurationShouldNotBeNull() {
+  @Test public void observeInternetConnectivityWithFullConfigurationShouldNotBeNull() {
     // given
     Observable<Boolean> observable;
     int initialInterval = TEST_VALID_INITIAL_INTERVAL;
@@ -114,7 +110,8 @@ import static com.google.common.truth.Truth.assertThat;
     int timeout = TEST_VALID_TIMEOUT;
 
     // when
-    observable = ReactiveNetwork.observeInternetConnectivity(initialInterval, interval, host, port, timeout);
+    observable =
+        ReactiveNetwork.observeInternetConnectivity(initialInterval, interval, host, port, timeout);
 
     // then
     assertThat(observable).isNotNull();
@@ -275,8 +272,7 @@ import static com.google.common.truth.Truth.assertThat;
     // an exception is thrown
   }
 
-  @Test
-  public void observeInternetConnectivityShouldNotThrowAnExceptionForZeroInitialInterval() {
+  @Test public void observeInternetConnectivityShouldNotThrowAnExceptionForZeroInitialInterval() {
     // given
     Observable<Boolean> observable;
     int initialInterval = 0;
@@ -286,7 +282,8 @@ import static com.google.common.truth.Truth.assertThat;
     int timeout = TEST_VALID_TIMEOUT;
 
     // when
-    observable = ReactiveNetwork.observeInternetConnectivity(initialInterval, interval, host, port, timeout);
+    observable =
+        ReactiveNetwork.observeInternetConnectivity(initialInterval, interval, host, port, timeout);
 
     // then
     assertThat(observable).isNotNull();
@@ -303,6 +300,43 @@ import static com.google.common.truth.Truth.assertThat;
 
     // when
     ReactiveNetwork.observeInternetConnectivity(initialInterval, interval, host, port, timeout);
+
+    // then
+    // an exception is thrown
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void observeInternetConnectivityShouldThrowAnExceptionWhenSocketErrorHandlerIsNull() {
+    // given
+    int initialInterval = -1;
+    int interval = TEST_VALID_INTERVAL;
+    String host = TEST_VALID_HOST;
+    int port = TEST_VALID_PORT;
+    int timeout = TEST_VALID_TIMEOUT;
+    SocketErrorHandler socketErrorHandler = null;
+
+    // when
+    ReactiveNetwork.observeInternetConnectivity(initialInterval, interval, host, port, timeout,
+        socketErrorHandler);
+
+    // then
+    // an exception is thrown
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void observeInternetConnectivityShouldThrowAnExceptionWhenStrategyIsNull() {
+    // given
+    InternetObservingStrategy strategy = null;
+    int initialInterval = -1;
+    int interval = TEST_VALID_INTERVAL;
+    String host = TEST_VALID_HOST;
+    int port = TEST_VALID_PORT;
+    int timeout = TEST_VALID_TIMEOUT;
+    SocketErrorHandler socketErrorHandler = new DefaultSocketErrorHandler();
+
+    // when
+    ReactiveNetwork.observeInternetConnectivity(strategy, initialInterval, interval, host, port,
+        timeout, socketErrorHandler);
 
     // then
     // an exception is thrown

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/internet/observing/InternetObservingStrategy.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/internet/observing/InternetObservingStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Piotr Wittchen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pwittchen.reactivenetwork.library.internet.observing;
+
+import com.github.pwittchen.reactivenetwork.library.internet.socket.SocketErrorHandler;
+import rx.Observable;
+
+/**
+ * Internet observing strategy allows to implement different strategies for monitoring connectivity
+ * with the Internet.
+ */
+public interface InternetObservingStrategy {
+  /**
+   * Observes connectivity with the Internet by opening socket connection with remote host
+   *
+   * @param initialIntervalInMs in milliseconds determining the delay of the first connectivity
+   * check
+   * @param intervalInMs in milliseconds determining how often we want to check connectivity
+   * @param host for checking Internet connectivity
+   * @param port for checking Internet connectivity
+   * @param timeoutInMs for pinging remote host in milliseconds
+   * @param socketErrorHandler for handling errors while closing socket
+   * @return RxJava Observable with Boolean - true, when we have connection with host and false if
+   * not
+   */
+  Observable<Boolean> observeInternetConnectivity(final int initialIntervalInMs,
+      final int intervalInMs, final String host, final int port, final int timeoutInMs,
+      final SocketErrorHandler socketErrorHandler);
+}

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/internet/observing/strategy/DefaultInternetObservingStrategy.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/internet/observing/strategy/DefaultInternetObservingStrategy.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016 Piotr Wittchen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pwittchen.reactivenetwork.library.internet.observing.strategy;
+
+import com.github.pwittchen.reactivenetwork.library.Preconditions;
+import com.github.pwittchen.reactivenetwork.library.internet.observing.InternetObservingStrategy;
+import com.github.pwittchen.reactivenetwork.library.internet.socket.SocketErrorHandler;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+import rx.Observable;
+import rx.functions.Func1;
+import rx.schedulers.Schedulers;
+
+/**
+ * Default strategy for monitoring connectivity with the Internet
+ */
+public class DefaultInternetObservingStrategy implements InternetObservingStrategy {
+  /**
+   * Observes connectivity with the Internet by opening socket connection with remote host
+   *
+   * @param initialIntervalInMs in milliseconds determining the delay of the first connectivity
+   * check
+   * @param intervalInMs in milliseconds determining how often we want to check connectivity
+   * @param host for checking Internet connectivity
+   * @param port for checking Internet connectivity
+   * @param timeoutInMs for pinging remote host in milliseconds
+   * @param socketErrorHandler for handling errors while closing socket
+   * @return RxJava Observable with Boolean - true, when we have connection with host and false if
+   * not
+   */
+  @Override public Observable<Boolean> observeInternetConnectivity(final int initialIntervalInMs,
+      final int intervalInMs, final String host, final int port, final int timeoutInMs,
+      final SocketErrorHandler socketErrorHandler) {
+    Preconditions.checkGreaterOrEqualToZero(initialIntervalInMs,
+        "initialIntervalInMs is not a positive number");
+    Preconditions.checkGreaterThanZero(intervalInMs, "intervalInMs is not a positive number");
+    Preconditions.checkNotNullOrEmpty(host, "host is null or empty");
+    Preconditions.checkGreaterThanZero(port, "port is not a positive number");
+    Preconditions.checkGreaterThanZero(timeoutInMs, "timeoutInMs is not a positive number");
+    Preconditions.checkNotNull(socketErrorHandler, "socketErrorHandler is null");
+
+    return Observable.interval(initialIntervalInMs, intervalInMs, TimeUnit.MILLISECONDS,
+        Schedulers.io()).map(new Func1<Long, Boolean>() {
+
+      boolean isConnected;
+
+      @Override public Boolean call(Long tick) {
+        Socket socket = new Socket();
+        try {
+          socket.connect(new InetSocketAddress(host, port), timeoutInMs);
+          isConnected = socket.isConnected();
+        } catch (IOException e) {
+          isConnected = Boolean.FALSE;
+        } finally {
+          try {
+            socket.close();
+          } catch (IOException exception) {
+            socketErrorHandler.handleErrorDuringClosingSocket(exception);
+          }
+        }
+        return isConnected;
+      }
+    }).distinctUntilChanged();
+  }
+}

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/internet/socket/DefaultSocketErrorHandler.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/internet/socket/DefaultSocketErrorHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016 Piotr Wittchen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pwittchen.reactivenetwork.library.internet.socket;
+
+import android.util.Log;
+
+import static com.github.pwittchen.reactivenetwork.library.ReactiveNetwork.LOG_TAG;
+
+public class DefaultSocketErrorHandler implements SocketErrorHandler {
+  public static final String ON_ERROR_MSG = "Could not close the socket";
+
+  @Override public void handleErrorDuringClosingSocket(Exception exception) {
+    Log.e(LOG_TAG, ON_ERROR_MSG, exception);
+  }
+}

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/internet/socket/SocketErrorHandler.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/internet/socket/SocketErrorHandler.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016 Piotr Wittchen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pwittchen.reactivenetwork.library.internet.socket;
+
+public interface SocketErrorHandler {
+  void handleErrorDuringClosingSocket(Exception exception);
+}

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/network/observing/strategy/LollipopNetworkObservingStrategy.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/network/observing/strategy/LollipopNetworkObservingStrategy.java
@@ -28,11 +28,12 @@ import rx.Observable;
 import rx.Subscriber;
 import rx.functions.Action0;
 
+import static com.github.pwittchen.reactivenetwork.library.ReactiveNetwork.LOG_TAG;
+
 /**
  * Network observing strategy for devices with Android Lollipop (API 21) or higher
  */
 @TargetApi(21) public class LollipopNetworkObservingStrategy implements NetworkObservingStrategy {
-  private final static String LOG_TAG = "ReactiveNetwork";
   private static final String ON_ERROR_MSG = "could not unregister network callback";
   private NetworkCallback networkCallback;
 

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/network/observing/strategy/PreLollipopNetworkObservingStrategy.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/network/observing/strategy/PreLollipopNetworkObservingStrategy.java
@@ -32,11 +32,12 @@ import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action0;
 import rx.subscriptions.Subscriptions;
 
+import static com.github.pwittchen.reactivenetwork.library.ReactiveNetwork.LOG_TAG;
+
 /**
  * Network observing strategy for Android devices before Lollipop (API 20 or lower)
  */
 public class PreLollipopNetworkObservingStrategy implements NetworkObservingStrategy {
-  private final static String LOG_TAG = "ReactiveNetwork";
   private static final String ON_ERROR_MSG = "receiver was already unregistered";
 
   @Override public Observable<Connectivity> observeNetworkConnectivity(final Context context) {


### PR DESCRIPTION
List of updates in this PR:
- closing socket during observing Internet connectivity
- delegating observing Internet connectivity to separate class
- adding an Interface, which allows implementing InternetObservingStrategy
- adding DefaultInternetObservingStrategy
- adding an interface, which allows handling errors during closing socket while observing Internet connectivity
- adding default implementation of SocketErrorHandler

Solves issue #91.