### PR TITLE
RxJava1.x: Fixing network filtering inside ConnectivityPredicate#hasT…

### DIFF
--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/Connectivity.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/Connectivity.java
@@ -23,6 +23,9 @@ import android.net.NetworkInfo;
  * Connectivity class represents current connectivity status. It wraps NetworkInfo object.
  */
 public class Connectivity {
+  static final int UNKNOWN_TYPE = -1;
+  static final int UNKNOWN_SUB_TYPE = -1;
+
   private NetworkInfo.State state;
   private NetworkInfo.DetailedState detailedState;
   private int type;
@@ -224,8 +227,8 @@ public class Connectivity {
 
     private NetworkInfo.State state = NetworkInfo.State.DISCONNECTED; // NOPMD
     private NetworkInfo.DetailedState detailedState = NetworkInfo.DetailedState.IDLE; // NOPMD
-    private int type = -1; // NOPMD
-    private int subType = -1; // NOPMD
+    private int type = UNKNOWN_TYPE; // NOPMD
+    private int subType = UNKNOWN_SUB_TYPE; // NOPMD
     private boolean available = false; // NOPMD
     private boolean failover = false; // NOPMD
     private boolean roaming = false; // NOPMD

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/ConnectivityPredicate.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/ConnectivityPredicate.java
@@ -53,9 +53,10 @@ public class ConnectivityPredicate {
    * @return true if at least one given type occurred
    */
   public static Func1<Connectivity, Boolean> hasType(final int... types) {
+    final int[] extendedTypes = appendUnknownNetworkTypeToTypes(types);
     return new Func1<Connectivity, Boolean>() {
       @Override public Boolean call(Connectivity connectivity) {
-        for (int type : types) {
+        for (int type : extendedTypes) {
           if (connectivity.getType() == type) {
             return true;
           }
@@ -63,5 +64,24 @@ public class ConnectivityPredicate {
         return false;
       }
     };
+  }
+
+  /**
+   * Returns network types from the input with additional unknown type,
+   * what helps during connections filtering when device
+   * is being disconnected from a specific network
+   *
+   * @param types of the network as an array of ints
+   * @return types of the network with unknown type as an array of ints
+   */
+  protected static int[] appendUnknownNetworkTypeToTypes(int[] types) {
+    int i = 0;
+    final int[] extendedTypes = new int[types.length + 1];
+    for (int type : types) {
+      extendedTypes[i] = type;
+      i++;
+    }
+    extendedTypes[i] = Connectivity.UNKNOWN_TYPE;
+    return extendedTypes;
   }
 }

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/ConnectivityTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/ConnectivityTest.java
@@ -88,7 +88,9 @@ public class ConnectivityTest {
         .typeName(TYPE_NAME_MOBILE)
         .build();
 
-    final int givenTypes[] = { ConnectivityManager.TYPE_WIFI, ConnectivityManager.TYPE_MOBILE };
+    final int givenTypes[] = {
+        ConnectivityManager.TYPE_WIFI, ConnectivityManager.TYPE_MOBILE, Connectivity.UNKNOWN_TYPE
+    };
 
     // when
     final Func1<Connectivity, Boolean> equalTo = ConnectivityPredicate.hasType(givenTypes);
@@ -154,6 +156,33 @@ public class ConnectivityTest {
 
     // then
     assertThat(hashCodesAreEqual).isTrue();
+  }
+
+  @Test public void shouldAppendUnknownTypeWhileFilteringNetworkTypesInsidePredicate() {
+    // given
+    int[] types = { ConnectivityManager.TYPE_MOBILE, ConnectivityManager.TYPE_WIFI };
+    int[] expectedOutputTypes = {
+        ConnectivityManager.TYPE_MOBILE, ConnectivityManager.TYPE_WIFI, Connectivity.UNKNOWN_TYPE
+    };
+
+    // when
+    int[] outputTypes = ConnectivityPredicate.appendUnknownNetworkTypeToTypes(types);
+
+    // then
+    assertThat(outputTypes).isEqualTo(expectedOutputTypes);
+  }
+
+  @Test
+  public void shouldAppendUnknownTypeWhileFilteringNetworkTypesInsidePredicateForEmptyArray() {
+    // given
+    int[] types = {};
+    int[] expectedOutputTypes = { Connectivity.UNKNOWN_TYPE };
+
+    // when
+    int[] outputTypes = ConnectivityPredicate.appendUnknownNetworkTypeToTypes(types);
+
+    // then
+    assertThat(outputTypes).isEqualTo(expectedOutputTypes);
   }
 
   @Test public void shouldCreateConnectivityWithBuilder() {


### PR DESCRIPTION
…ype method by adding unknown netowrk type as initial type in the filters array - fixes #159