### PR TITLE
RxJava2.x: adding documentation for NetworkObservingStrategy & Intern…

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Right now, we have the following strategies for observing Internet connectivity:
 - `WalledGardenInternetObservingStrategy` - opens connection with a remote host and respects countries in the Walled Garden (e.g. China)
 
 All of these strategies implements `NetworkObservingStrategy` interface. Default strategy used right now is `WalledGardenInternetObservingStrategy`,
-but with `checkInternetConnectivity(strategy)` method we can use one of these strategies explicitly.
+but with `checkInternetConnectivity(strategy)` and `observeInternetConnectivity(strategy)` method we can use one of these strategies explicitly.
 
 ### ProGuard configuration
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ Right now, we have the following strategies for observing Internet connectivity:
 - `SocketInternetObservingStrategy` -  monitors Internet connectivity via opening socket connection with the remote host
 - `WalledGardenInternetObservingStrategy` - opens connection with a remote host and respects countries in the Walled Garden (e.g. China)
 
-Default strategy used right now is `WalledGardenInternetObservingStrategy`, but with
-`checkInternetConnectivity(strategy)` method we can use one of these strategies explicitly.
+All of these strategies implements `NetworkObservingStrategy` interface. Default strategy used right now is `WalledGardenInternetObservingStrategy`,
+but with `checkInternetConnectivity(strategy)` method we can use one of these strategies explicitly.
 
 ### ProGuard configuration
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ Contents
 - [Usage](#usage)
   - [Observing network connectivity](#observing-network-connectivity)
     - [Connectivity class](#connectivity-class)
+    - [Network Observing Strategies](#network-observing-strategies)
   - [Observing Internet connectivity](#observing-internet-connectivity)
     - [Observing Internet connectivity continuously](#observing-internet-connectivity-continuously)
     - [Checking Internet connectivity once](#checking-internet-connectivity-once)
+    - [Internet Observing Strategies](#internet-observing-strategies)
   - [ProGuard configuration](#proguard-configuration)
 - [Examples](#examples)
 - [Download](#download)
@@ -116,6 +118,17 @@ String getExtraInfo()
 class Builder
 ```
 
+#### Network Observing Strategies
+
+Right now, we have the following strategies for different Android versions:
+- `LollipopNetworkObservingStrategy`
+- `MarshmallowNetworkObservingStrategy`
+- `PreLollipopNetworkObservingStrategy`
+
+All of them implements `NetworkObservingStrategy` interface.
+Concrete strategy is chosen automatically depending on the Android version installed on the device.
+With `observeNetworkConnectivity(context, strategy)` method we can use one of these strategies explicitly.
+
 ### Observing Internet connectivity
 
 #### Observing Internet connectivity continuously
@@ -190,6 +203,15 @@ and we don't have `int initialIntervalInMs` and `int intervalInMs` parameters.
 As previously, these methods are created to allow the users to fully customize the library and give them more control.
 
 For more details check JavaDoc at: http://pwittchen.github.io/ReactiveNetwork/
+
+#### Internet Observing Strategies
+
+Right now, we have the following strategies for observing Internet connectivity:
+- `SocketInternetObservingStrategy` -  monitors Internet connectivity via opening socket connection with the remote host
+- `WalledGardenInternetObservingStrategy` - opens connection with a remote host and respects countries in the Walled Garden (e.g. China)
+
+Default strategy used right now is `WalledGardenInternetObservingStrategy`, but with
+`checkInternetConnectivity(strategy)` method we can use one of these strategies explicitly.
 
 ### ProGuard configuration
 


### PR DESCRIPTION
…etObservingStrategy - fixes #197 & #198

**Side note**: remember to update docs for `RxJava1.x` branch within a separate PR. It should look almost the same (or maybe even exactly the same).