### PR TITLE
Add configuration to run NullAway

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,16 @@ ext.deps = [rxjava2           : 'io.reactivex.rxjava2:rxjava:2.1.2',
 buildscript {
   repositories {
     jcenter()
+    maven {
+      url 'https://plugins.gradle.org/m2/'
+    }
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:2.3.3'
     classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
     classpath 'me.tatarka:gradle-retrolambda:3.7.0'
-
+    classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.11'
+    classpath 'net.ltgt.gradle:gradle-apt-plugin:0.11'
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
   }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: 'jacoco'
 apply plugin: 'jacoco-android'
+apply plugin: 'net.ltgt.errorprone'
+apply plugin: 'net.ltgt.apt'
 apply from: '../config/quality.gradle'
 apply from: '../maven_push.gradle'
 
@@ -56,8 +58,18 @@ dependencies {
   testCompile deps.truth
   testCompile deps.robolectric
   testCompile deps.mockitocore
+
+  annotationProcessor 'com.uber.nullaway:nullaway:0.1.2'
+
+  errorprone 'com.google.errorprone:error_prone_core:2.1.1'
 }
 
 task wrapper(type: Wrapper) {
   gradleVersion = rootProject.ext.gradleVersion
+}
+
+tasks.withType(JavaCompile) {
+  if (!name.toLowerCase().contains("test")) {
+    options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.github.pwittchen.reactivenetwork"]
+  }
 }


### PR DESCRIPTION
I figured out one way to add NullAway to the project (may not be the absolute cleanest).  We will update our READMEs to be more clear about this type of scenario (see uber/NullAway#10).  Note that you'll have to fix the NullAway errors before merging this back, which may require adding some number of code annotations.