### PR TITLE
Refactoring ReactiveNetwork class with builder pattern - solves #271

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,16 +158,28 @@ Internet connectivity will be checked _as soon as possible_.
 
 Methods in this section should be used if they are really needed due to specific use cases.
 
-If you want to customize observing of the Internet connectivity, you can use one of the methods below.
+If you want to customize observing of the Internet connectivity, you can use `InternetObservingSettings` class and its builder.
 They allow to customize monitoring interval in milliseconds, host, port, timeout, initial monitoring interval, timeout, error handler or whole observing strategy.
 
 ```java
-Observable<Boolean> observeInternetConnectivity(int interval, String host, int port, int timeout)
-Observable<Boolean> observeInternetConnectivity(int initialIntervalInMs, int intervalInMs, String host, int port, int timeout)
-Observable<Boolean> observeInternetConnectivity(final int initialIntervalInMs, final int intervalInMs, final String host, final int port, final int timeoutInMs, final ErrorHandler errorHandler)
-Observable<Boolean> observeInternetConnectivity(final InternetObservingStrategy strategy, final int initialIntervalInMs, final int intervalInMs, final String host, final int port, final int timeoutInMs, final ErrorHandler errorHandler)
-Observable<Boolean> observeInternetConnectivity(final InternetObservingStrategy strategy)
-Observable<Boolean> observeInternetConnectivity(final InternetObservingStrategy strategy, final String host)
+InternetObservingSettings settings = InternetObservingSettings
+    .initialInterval(initialInterval)
+    .interval(interval)
+    .host(host)
+    .port(port)
+    .timeout(timeout)
+    .errorHandler(testErrorHandler)
+    .strategy(strategy)
+    .build();
+
+ReactiveNetwork.observeInternetConnectivity(settings)
+        .subscribeOn(Schedulers.io())
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribe(new Consumer<Boolean>() {
+          @Override public void accept(Boolean isConnectedToInternet) {
+            // do something with isConnectedToInternet value
+          }
+        });
 ```
 
 These methods are created to allow the users to fully customize the library and give them more control.
@@ -193,14 +205,29 @@ single
     });
 ```
 
-As in the previous case, you can customize this feature with the following methods from `ReactiveNetwork` class:
+As in the previous case, you can customize this feature with the `InternetObservingSettings` class and its builder.
 
 ```java
-Single<Boolean> checkInternetConnectivity(InternetObservingStrategy strategy)
-Single<Boolean> checkInternetConnectivity(String host,int port, int timeoutInMs)
-Single<Boolean> checkInternetConnectivity(String host, int port, int timeoutInMs, ErrorHandler errorHandler)
-Single<Boolean> checkInternetConnectivity(InternetObservingStrategy strategy, String host, int port, int timeoutInMs, ErrorHandler errorHandler)
-Single<Boolean> checkInternetConnectivity(final InternetObservingStrategy strategy, final String host)
+InternetObservingSettings settings = InternetObservingSettings
+    .initialInterval(initialInterval)
+    .interval(interval)
+    .host(host)
+    .port(port)
+    .timeout(timeout)
+    .errorHandler(testErrorHandler)
+    .strategy(strategy)
+    .build();
+
+Single<Boolean> single = ReactiveNetwork.checkInternetConnectivity(settings);
+
+single
+    .subscribeOn(Schedulers.io())
+    .observeOn(AndroidSchedulers.mainThread())
+    .subscribe(new Consumer<Boolean>() {
+      @Override public void accept(@NonNull Boolean isConnectedToTheInternet) throws Exception {
+        // do something with isConnectedToTheInternet
+      }
+    });
 ```
 
 Basic idea is the same. With just have `Single<Boolean>` return type instead of `Observable<Boolean>`

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetwork.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetwork.java
@@ -18,10 +18,9 @@ package com.github.pwittchen.reactivenetwork.library.rx2;
 import android.Manifest;
 import android.content.Context;
 import android.support.annotation.RequiresPermission;
+import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.InternetObservingSettings;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.InternetObservingStrategy;
-import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.DefaultErrorHandler;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.ErrorHandler;
-import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.strategy.WalledGardenInternetObservingStrategy;
 import com.github.pwittchen.reactivenetwork.library.rx2.network.observing.NetworkObservingStrategy;
 import com.github.pwittchen.reactivenetwork.library.rx2.network.observing.strategy.LollipopNetworkObservingStrategy;
 import com.github.pwittchen.reactivenetwork.library.rx2.network.observing.strategy.MarshmallowNetworkObservingStrategy;
@@ -36,11 +35,6 @@ import io.reactivex.Single;
  */
 public class ReactiveNetwork {
   public final static String LOG_TAG = "ReactiveNetwork";
-  private static final String DEFAULT_PING_HOST = "http://clients3.google.com/generate_204";
-  private static final int DEFAULT_PING_PORT = 80;
-  private static final int DEFAULT_PING_INTERVAL_IN_MS = 2000;
-  private static final int DEFAULT_INITIAL_PING_INTERVAL_IN_MS = 0;
-  private static final int DEFAULT_PING_TIMEOUT_IN_MS = 2000;
 
   protected ReactiveNetwork() {
   }
@@ -109,108 +103,25 @@ public class ReactiveNetwork {
    */
   @RequiresPermission(Manifest.permission.INTERNET)
   public static Observable<Boolean> observeInternetConnectivity() {
-    return observeInternetConnectivity(DEFAULT_INITIAL_PING_INTERVAL_IN_MS,
-        DEFAULT_PING_INTERVAL_IN_MS, DEFAULT_PING_HOST, DEFAULT_PING_PORT,
-        DEFAULT_PING_TIMEOUT_IN_MS, new DefaultErrorHandler());
+    InternetObservingSettings settings = InternetObservingSettings.create();
+    return observeInternetConnectivity(settings.strategy(), settings.initialInterval(),
+        settings.interval(), settings.host(), settings.port(),
+        settings.timeout(), settings.errorHandler());
   }
 
   /**
-   * Observes connectivity with the Internet with default settings,
-   * but with custom InternetObservingStrategy. It pings remote host
-   * (www.google.com) at port 80 every 2 seconds with 2 seconds of timeout. This operation is used
-   * for determining if device is connected to the Internet or not. Please note that this method is
-   * less efficient than {@link #observeNetworkConnectivity(Context)} method and consumes data
-   * transfer, but it gives you actual information if device is connected to the Internet or not.
+   * Observes connectivity with the Internet in a given time interval.
    *
-   * @param strategy which implements InternetObservingStrategy
-   * @return RxJava Observable with Boolean - true, when we have an access to the Internet
-   * and false if not
+   * @param settings Internet Observing Settings created via Builder pattern
+   * @return RxJava Observable with Boolean - true, when we have connection with host and false if
+   * not
    */
   @RequiresPermission(Manifest.permission.INTERNET)
   public static Observable<Boolean> observeInternetConnectivity(
-      final InternetObservingStrategy strategy) {
-    checkStrategyIsNotNull(strategy);
-    return strategy.observeInternetConnectivity(DEFAULT_INITIAL_PING_INTERVAL_IN_MS,
-        DEFAULT_PING_INTERVAL_IN_MS, strategy.getDefaultPingHost(), DEFAULT_PING_PORT,
-        DEFAULT_PING_TIMEOUT_IN_MS, new DefaultErrorHandler());
-  }
-
-  /**
-   * Observes connectivity with the Internet with default settings,
-   * but with custom InternetObservingStrategy and host. It pings remote host
-   * at port 80 every 2 seconds with 2 seconds of timeout. This operation is used
-   * for determining if device is connected to the Internet or not. Please note that this method is
-   * less efficient than {@link #observeNetworkConnectivity(Context)} method and consumes data
-   * transfer, but it gives you actual information if device is connected to the Internet or not.
-   *
-   * @param strategy which implements InternetObservingStrategy
-   * @param host for checking Internet connectivity
-   * @return RxJava Observable with Boolean - true, when we have connection with host and false if
-   * not
-   */
-  public static Observable<Boolean> observeInternetConnectivity(
-      final InternetObservingStrategy strategy, final String host) {
-    checkStrategyIsNotNull(strategy);
-    return strategy.observeInternetConnectivity(DEFAULT_INITIAL_PING_INTERVAL_IN_MS,
-        DEFAULT_PING_INTERVAL_IN_MS, host, DEFAULT_PING_PORT, DEFAULT_PING_TIMEOUT_IN_MS,
-        new DefaultErrorHandler());
-  }
-
-  /**
-   * Observes connectivity with the Internet in a given time interval.
-   *
-   * @param intervalInMs in milliseconds determining how often we want to check connectivity
-   * @param host for checking Internet connectivity
-   * @param port for checking Internet connectivity
-   * @param timeoutInMs for pinging remote host in milliseconds
-   * @return RxJava Observable with Boolean - true, when we have connection with host and false if
-   * not
-   */
-  @RequiresPermission(Manifest.permission.INTERNET)
-  public static Observable<Boolean> observeInternetConnectivity(final int intervalInMs,
-      final String host, final int port, final int timeoutInMs) {
-    return observeInternetConnectivity(DEFAULT_INITIAL_PING_INTERVAL_IN_MS, intervalInMs, host,
-        port, timeoutInMs, new DefaultErrorHandler());
-  }
-
-  /**
-   * Observes connectivity with the Internet in a given time interval.
-   *
-   * @param initialIntervalInMs in milliseconds determining the delay of the first connectivity
-   * check
-   * @param intervalInMs in milliseconds determining how often we want to check connectivity
-   * @param host for checking Internet connectivity
-   * @param port for checking Internet connectivity
-   * @param timeoutInMs for pinging remote host in milliseconds
-   * @return RxJava Observable with Boolean - true, when we have connection with host and false if
-   * not
-   */
-  @RequiresPermission(Manifest.permission.INTERNET)
-  public static Observable<Boolean> observeInternetConnectivity(final int initialIntervalInMs,
-      final int intervalInMs, final String host, final int port, final int timeoutInMs) {
-    return observeInternetConnectivity(initialIntervalInMs, intervalInMs, host, port, timeoutInMs,
-        new DefaultErrorHandler());
-  }
-
-  /**
-   * Observes connectivity with the Internet in a given time interval.
-   *
-   * @param initialIntervalInMs in milliseconds determining the delay of the first connectivity
-   * check
-   * @param intervalInMs in milliseconds determining how often we want to check connectivity
-   * @param host for checking Internet connectivity
-   * @param port for checking Internet connectivity
-   * @param timeoutInMs for pinging remote host in milliseconds
-   * @param errorHandler for handling errors during connectivity check
-   * @return RxJava Observable with Boolean - true, when we have connection with host and false if
-   * not
-   */
-  @RequiresPermission(Manifest.permission.INTERNET)
-  public static Observable<Boolean> observeInternetConnectivity(final int initialIntervalInMs,
-      final int intervalInMs, final String host, final int port, final int timeoutInMs,
-      final ErrorHandler errorHandler) {
-    return observeInternetConnectivity(new WalledGardenInternetObservingStrategy(),
-        initialIntervalInMs, intervalInMs, host, port, timeoutInMs, errorHandler);
+      InternetObservingSettings settings) {
+    return observeInternetConnectivity(settings.strategy(), settings.initialInterval(),
+        settings.interval(), settings.host(), settings.port(),
+        settings.timeout(), settings.errorHandler());
   }
 
   /**
@@ -228,7 +139,7 @@ public class ReactiveNetwork {
    * not
    */
   @RequiresPermission(Manifest.permission.INTERNET)
-  public static Observable<Boolean> observeInternetConnectivity(
+  protected static Observable<Boolean> observeInternetConnectivity(
       final InternetObservingStrategy strategy, final int initialIntervalInMs,
       final int intervalInMs, final String host, final int port, final int timeoutInMs,
       final ErrorHandler errorHandler) {
@@ -245,70 +156,22 @@ public class ReactiveNetwork {
    */
   @RequiresPermission(Manifest.permission.INTERNET)
   public static Single<Boolean> checkInternetConnectivity() {
-    return checkInternetConnectivity(DEFAULT_PING_HOST, DEFAULT_PING_PORT,
-        DEFAULT_PING_TIMEOUT_IN_MS, new DefaultErrorHandler());
+    InternetObservingSettings settings = InternetObservingSettings.create();
+    return checkInternetConnectivity(settings.strategy(), settings.host(), settings.port(),
+        settings.timeout(), settings.errorHandler());
   }
 
   /**
    * Checks connectivity with the Internet. This operation is performed only once.
    *
-   * @param strategy which implements InternetObservingStrategy
-   * @return RxJava Single with Boolean - true, when we have an access to the Internet
-   * and false if not
-   */
-  @RequiresPermission(Manifest.permission.INTERNET)
-  public static Single<Boolean> checkInternetConnectivity(
-      final InternetObservingStrategy strategy) {
-    checkStrategyIsNotNull(strategy);
-    return strategy.checkInternetConnectivity(strategy.getDefaultPingHost(), DEFAULT_PING_PORT,
-        DEFAULT_PING_TIMEOUT_IN_MS, new DefaultErrorHandler());
-  }
-
-  /**
-   * Checks connectivity with the Internet. This operation is performed only once.
-   *
-   * @param strategy which implements InternetObservingStrategy
-   * @param host for checking Internet connectivity
-   * @return RxJava Single with Boolean - true, when we have an access to the Internet
-   * and false if not
-   */
-  public static Single<Boolean> checkInternetConnectivity(final InternetObservingStrategy strategy,
-      final String host) {
-    checkStrategyIsNotNull(strategy);
-    return strategy.checkInternetConnectivity(host, DEFAULT_PING_PORT,
-        DEFAULT_PING_TIMEOUT_IN_MS, new DefaultErrorHandler());
-  }
-
-  /**
-   * Checks connectivity with the Internet. This operation is performed only once.
-   *
-   * @param host for checking Internet connectivity
-   * @param port for checking Internet connectivity
-   * @param timeoutInMs for pinging remote host in milliseconds
+   * @param settings Internet Observing Settings created via Builder pattern
    * @return RxJava Single with Boolean - true, when we have connection with host and false if
    * not
    */
   @RequiresPermission(Manifest.permission.INTERNET)
-  public static Single<Boolean> checkInternetConnectivity(final String host, final int port,
-      final int timeoutInMs) {
-    return checkInternetConnectivity(host, port, timeoutInMs, new DefaultErrorHandler());
-  }
-
-  /**
-   * Checks connectivity with the Internet. This operation is performed only once.
-   *
-   * @param host for checking Internet connectivity
-   * @param port for checking Internet connectivity
-   * @param timeoutInMs for pinging remote host in milliseconds
-   * @param errorHandler for handling errors during connectivity check
-   * @return RxJava Single with Boolean - true, when we have connection with host and false if
-   * not
-   */
-  @RequiresPermission(Manifest.permission.INTERNET)
-  public static Single<Boolean> checkInternetConnectivity(final String host, final int port,
-      final int timeoutInMs, final ErrorHandler errorHandler) {
-    return checkInternetConnectivity(new WalledGardenInternetObservingStrategy(), host, port,
-        timeoutInMs, errorHandler);
+  public static Single<Boolean> checkInternetConnectivity(InternetObservingSettings settings) {
+    return checkInternetConnectivity(settings.strategy(), settings.host(), settings.port(),
+        settings.timeout(), settings.errorHandler());
   }
 
   /**
@@ -323,7 +186,8 @@ public class ReactiveNetwork {
    * not
    */
   @RequiresPermission(Manifest.permission.INTERNET)
-  public static Single<Boolean> checkInternetConnectivity(final InternetObservingStrategy strategy,
+  protected static Single<Boolean> checkInternetConnectivity(
+      final InternetObservingStrategy strategy,
       final String host, final int port, final int timeoutInMs, final ErrorHandler errorHandler) {
     checkStrategyIsNotNull(strategy);
     return strategy.checkInternetConnectivity(host, port, timeoutInMs, errorHandler);

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettings.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettings.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2018 Piotr Wittchen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pwittchen.reactivenetwork.library.rx2.internet.observing;
+
+import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.DefaultErrorHandler;
+import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.ErrorHandler;
+import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.strategy.WalledGardenInternetObservingStrategy;
+
+/**
+ * Contains state of internet connectivity settings.
+ * We should use its Builder for creating new settings
+ */
+@SuppressWarnings("PMD") // I want to have the same method names as variable names on purpose
+public final class InternetObservingSettings {
+  private final int initialInterval;
+  private final int interval;
+  private final String host;
+  private final int port;
+  private final int timeout;
+  private final ErrorHandler errorHandler;
+  private final InternetObservingStrategy strategy;
+
+  private InternetObservingSettings(int initialInterval, int interval, String host, int port,
+      int timeout,
+      ErrorHandler errorHandler, InternetObservingStrategy strategy) {
+    this.initialInterval = initialInterval;
+    this.interval = interval;
+    this.host = host;
+    this.port = port;
+    this.timeout = timeout;
+    this.errorHandler = errorHandler;
+    this.strategy = strategy;
+  }
+
+  /**
+   * @return settings with default parameters
+   */
+  public static InternetObservingSettings create() {
+    return new InternetObservingSettings.Builder().build();
+  }
+
+  private InternetObservingSettings(Builder builder) {
+    this(builder.initialInterval, builder.interval, builder.host, builder.port, builder.timeout,
+        builder.errorHandler, builder.strategy);
+  }
+
+  private InternetObservingSettings() {
+    this(builder());
+  }
+
+  private static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * @return initial ping interval in milliseconds
+   */
+  public int initialInterval() {
+    return initialInterval;
+  }
+
+  /**
+   * sets initial ping interval in milliseconds
+   *
+   * @param initialInterval in milliseconds
+   * @return Builder
+   */
+  public static Builder initialInterval(final int initialInterval) {
+    return builder().initialInterval(initialInterval);
+  }
+
+  /**
+   * @return ping interval in milliseconds
+   */
+  public int interval() {
+    return interval;
+  }
+
+  /**
+   * sets ping interval in milliseconds
+   *
+   * @param interval in milliseconds
+   * @return Builder
+   */
+  public static Builder interval(final int interval) {
+    return builder().interval(interval);
+  }
+
+  /**
+   * @return ping host
+   */
+  public String host() {
+    return host;
+  }
+
+  /**
+   * @return ping host
+   */
+  public static Builder host(final String host) {
+    return builder().host(host);
+  }
+
+  /**
+   * @return ping port
+   */
+  public int port() {
+    return port;
+  }
+
+  /**
+   * sets ping port
+   *
+   * @return Builder
+   */
+  public static Builder port(final int port) {
+    return builder().port(port);
+  }
+
+  /**
+   * @return ping timeout in milliseconds
+   */
+  public int timeout() {
+    return timeout;
+  }
+
+  /**
+   * sets ping timeout in milliseconds
+   *
+   * @param timeout in milliseconds
+   * @return Builder
+   */
+  public static Builder timeout(final int timeout) {
+    return builder().timeout(timeout);
+  }
+
+  /**
+   * @return error handler for pings and connections
+   */
+  public ErrorHandler errorHandler() {
+    return errorHandler;
+  }
+
+  /**
+   * sets error handler for pings and connections
+   *
+   * @return Builder
+   */
+  public static Builder errorHandler(final ErrorHandler errorHandler) {
+    return builder().errorHandler(errorHandler);
+  }
+
+  /**
+   * @return internet observing strategy
+   */
+  public InternetObservingStrategy strategy() {
+    return strategy;
+  }
+
+  /**
+   * sets internet observing strategy
+   *
+   * @param strategy for observing and internet connection
+   * @return Builder
+   */
+  public static Builder strategy(final InternetObservingStrategy strategy) {
+    return builder().strategy(strategy);
+  }
+
+  /**
+   * Settings builder, which contains default parameters
+   */
+  public final static class Builder {
+    private int initialInterval = 0;
+    private int interval = 2000;
+    private String host = "http://clients3.google.com/generate_204";
+    private int port = 80;
+    private int timeout = 2000;
+    private ErrorHandler errorHandler = new DefaultErrorHandler();
+    private InternetObservingStrategy strategy = new WalledGardenInternetObservingStrategy();
+
+    private Builder() {
+    }
+
+    public Builder initialInterval(int initialInterval) {
+      this.initialInterval = initialInterval;
+      return this;
+    }
+
+    public Builder interval(int interval) {
+      this.interval = interval;
+      return this;
+    }
+
+    public Builder host(String host) {
+      this.host = host;
+      return this;
+    }
+
+    public Builder port(int port) {
+      this.port = port;
+      return this;
+    }
+
+    public Builder timeout(int timeout) {
+      this.timeout = timeout;
+      return this;
+    }
+
+    public Builder errorHandler(ErrorHandler errorHandler) {
+      this.errorHandler = errorHandler;
+      return this;
+    }
+
+    public Builder strategy(InternetObservingStrategy strategy) {
+      this.strategy = strategy;
+      return this;
+    }
+
+    public InternetObservingSettings build() {
+      return new InternetObservingSettings(this);
+    }
+  }
+}

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetworkTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetworkTest.java
@@ -18,6 +18,8 @@ package com.github.pwittchen.reactivenetwork.library.rx2;
 import android.app.Application;
 import android.content.Context;
 import android.net.NetworkInfo;
+import android.support.annotation.NonNull;
+import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.InternetObservingSettings;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.InternetObservingStrategy;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.DefaultErrorHandler;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.ErrorHandler;
@@ -26,6 +28,8 @@ import com.github.pwittchen.reactivenetwork.library.rx2.network.observing.Networ
 import com.github.pwittchen.reactivenetwork.library.rx2.network.observing.strategy.LollipopNetworkObservingStrategy;
 import io.reactivex.Observable;
 import io.reactivex.Single;
+import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -104,26 +108,6 @@ import static com.google.common.truth.Truth.assertThat;
     assertThat(observable).isNotNull();
   }
 
-  @Test public void observeInternetConnectivityWithConfigurationShouldNotBeNull() {
-    // when
-    final Observable<Boolean> observable =
-        ReactiveNetwork.observeInternetConnectivity(TEST_VALID_INTERVAL, TEST_VALID_HOST,
-            TEST_VALID_PORT, TEST_VALID_TIMEOUT);
-
-    // then
-    assertThat(observable).isNotNull();
-  }
-
-  @Test public void observeInternetConnectivityWithFullConfigurationShouldNotBeNull() {
-    // when
-    final Observable<Boolean> observable =
-        ReactiveNetwork.observeInternetConnectivity(TEST_VALID_INITIAL_INTERVAL,
-            TEST_VALID_INTERVAL, TEST_VALID_HOST, TEST_VALID_PORT, TEST_VALID_TIMEOUT);
-
-    // then
-    assertThat(observable).isNotNull();
-  }
-
   @Test public void observeNetworkConnectivityShouldBeConnectedOnStartWhenNetworkIsAvailable() {
     // given
     final Application context = RuntimeEnvironment.application;
@@ -160,114 +144,6 @@ import static com.google.common.truth.Truth.assertThat;
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void observeInternetConnectivityShouldThrowAnExceptionForNegativeInterval() {
-    // given
-
-    // when
-    ReactiveNetwork.observeInternetConnectivity(-1, TEST_VALID_HOST, TEST_VALID_PORT,
-        TEST_VALID_TIMEOUT);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void observeInternetConnectivityShouldThrowAnExceptionForZeroInterval() {
-    // when
-    ReactiveNetwork.observeInternetConnectivity(0, TEST_VALID_HOST, TEST_VALID_PORT,
-        TEST_VALID_TIMEOUT);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void observeInternetConnectivityShouldThrowAnExceptionForNullHost() {
-    // when
-    ReactiveNetwork.observeInternetConnectivity(TEST_VALID_INTERVAL, null, TEST_VALID_PORT,
-        TEST_VALID_TIMEOUT);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void observeInternetConnectivityShouldThrowAnExceptionForEmptyHost() {
-    // given
-
-    // when
-    ReactiveNetwork.observeInternetConnectivity(TEST_VALID_INTERVAL, "", TEST_VALID_PORT,
-        TEST_VALID_TIMEOUT);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void observeInternetConnectivityShouldThrowAnExceptionForNegativePort() {
-    // given
-
-    // when
-    ReactiveNetwork.observeInternetConnectivity(TEST_VALID_INTERVAL, TEST_VALID_HOST, -1,
-        TEST_VALID_TIMEOUT);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void observeInternetConnectivityShouldThrowAnExceptionForZeroPort() {
-    // given
-
-    // when
-    ReactiveNetwork.observeInternetConnectivity(TEST_VALID_INTERVAL, TEST_VALID_HOST, 0,
-        TEST_VALID_TIMEOUT);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void observeInternetConnectivityShouldThrowAnExceptionForNegativeTimeout() {
-    // when
-    ReactiveNetwork.observeInternetConnectivity(TEST_VALID_INTERVAL, TEST_VALID_HOST,
-        TEST_VALID_PORT, -1);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void observeInternetConnectivityShouldThrowAnExceptionForZeroTimeout() {
-    // when
-    ReactiveNetwork.observeInternetConnectivity(TEST_VALID_INTERVAL, TEST_VALID_HOST,
-        TEST_VALID_PORT, 0);
-
-    // then an exception is thrown
-  }
-
-  @Test public void observeInternetConnectivityShouldNotThrowAnExceptionForZeroInitialInterval() {
-    // when
-    final Observable<Boolean> observable =
-        ReactiveNetwork.observeInternetConnectivity(0, TEST_VALID_INTERVAL, TEST_VALID_HOST,
-            TEST_VALID_PORT, TEST_VALID_TIMEOUT);
-
-    // then
-    assertThat(observable).isNotNull();
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void observeInternetConnectivityShouldThrowAnExceptionForNegativeInitialInterval() {
-    // when
-    ReactiveNetwork.observeInternetConnectivity(-1, TEST_VALID_INTERVAL, TEST_VALID_HOST,
-        TEST_VALID_PORT, TEST_VALID_TIMEOUT);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void observeInternetConnectivityShouldThrowAnExceptionWhenSocketErrorHandlerIsNull() {
-    // when
-    ReactiveNetwork.observeInternetConnectivity(TEST_VALID_INITIAL_INTERVAL, TEST_VALID_INTERVAL,
-        TEST_VALID_HOST, TEST_VALID_PORT, TEST_VALID_TIMEOUT, null);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
   public void observeInternetConnectivityShouldThrowAnExceptionWhenStrategyIsNull() {
     // given
     final InternetObservingStrategy strategy = null;
@@ -296,86 +172,6 @@ import static com.google.common.truth.Truth.assertThat;
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void observeInternetConnectivityShouldThrowAnExceptionWhenJustStrategyIsNull() {
-    // given
-    final InternetObservingStrategy strategy = null;
-
-    // when
-    ReactiveNetwork.observeInternetConnectivity(strategy);
-
-    // then an exception is thrown
-  }
-
-  @Test
-  public void observeInternetConnectivityShouldNotThrowAnExceptionWhenJustStrategyIsNotNull() {
-    // given
-    final InternetObservingStrategy strategy = new SocketInternetObservingStrategy();
-
-    // when
-    final Observable<Boolean> observable = ReactiveNetwork.observeInternetConnectivity(strategy);
-
-    // then
-    assertThat(observable).isNotNull();
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void checkInternetConnectivityShouldThrowAnExceptionForNullHost() {
-    // when
-    ReactiveNetwork.checkInternetConnectivity(null, TEST_VALID_PORT, TEST_VALID_TIMEOUT);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void checkInternetConnectivityShouldThrowAnExceptionForEmptyHost() {
-    // when
-    ReactiveNetwork.checkInternetConnectivity("", TEST_VALID_PORT, TEST_VALID_TIMEOUT);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void checkInternetConnectivityShouldThrowAnExceptionForNegativePort() {
-    // when
-    ReactiveNetwork.checkInternetConnectivity(TEST_VALID_HOST, -1, TEST_VALID_TIMEOUT);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void checkInternetConnectivityShouldThrowAnExceptionForZeroPort() {
-    // when
-    ReactiveNetwork.checkInternetConnectivity(TEST_VALID_HOST, 0, TEST_VALID_TIMEOUT);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void checkInternetConnectivityShouldThrowAnExceptionForNegativeTimeout() {
-    // when
-    ReactiveNetwork.checkInternetConnectivity(TEST_VALID_HOST, TEST_VALID_PORT, -1);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void checkInternetConnectivityShouldThrowAnExceptionForZeroTimeout() {
-    // when
-    ReactiveNetwork.checkInternetConnectivity(TEST_VALID_HOST, TEST_VALID_PORT, 0);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void checkInternetConnectivityShouldThrowAnExceptionWhenSocketErrorHandlerIsNull() {
-    // when
-    ReactiveNetwork.checkInternetConnectivity(TEST_VALID_HOST, TEST_VALID_PORT, TEST_VALID_TIMEOUT,
-        null);
-
-    // then an exception is thrown
-  }
-
-  @Test(expected = IllegalArgumentException.class)
   public void checkInternetConnectivityShouldThrowAnExceptionWhenStrategyIsNull() {
     // given
     final ErrorHandler errorHandler = new DefaultErrorHandler();
@@ -401,25 +197,101 @@ import static com.google.common.truth.Truth.assertThat;
     assertThat(single).isNotNull();
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void checkInternetConnectivityShouldThrowAnExceptionWhenJustStrategyIsNull() {
+  @Test
+  public void shouldObserveInternetConnectivityWithCustomSettings() {
     // given
-    final InternetObservingStrategy strategy = null;
+    final int initialInterval = 1;
+    final int interval = 2;
+    final String host = "www.test.com";
+    int port = 90;
+    int timeout = 3;
+    ErrorHandler testErrorHandler = createTestErrorHandler();
+    InternetObservingStrategy strategy = createTestInternetObservingStrategy();
 
     // when
-    ReactiveNetwork.checkInternetConnectivity(strategy);
-
-    // then an exception is thrown
-  }
-
-  @Test public void checkInternetConnectivityShouldNotThrowAnExceptionWhenJustStrategyIsNotNull() {
-    // given
-    final InternetObservingStrategy strategy = new SocketInternetObservingStrategy();
-
-    // when
-    final Single<Boolean> single = ReactiveNetwork.checkInternetConnectivity(strategy);
+    InternetObservingSettings settings = InternetObservingSettings
+        .initialInterval(initialInterval)
+        .interval(interval)
+        .host(host)
+        .port(port)
+        .timeout(timeout)
+        .errorHandler(testErrorHandler)
+        .strategy(strategy)
+        .build();
 
     // then
+    Observable<Boolean> observable = ReactiveNetwork.observeInternetConnectivity(settings);
+    assertThat(observable).isNotNull();
+  }
+
+  @Test
+  public void shouldCheckInternetConnectivityWithCustomSettings() {
+    // given
+    final int initialInterval = 1;
+    final int interval = 2;
+    final String host = "www.test.com";
+    int port = 90;
+    int timeout = 3;
+    ErrorHandler testErrorHandler = createTestErrorHandler();
+    InternetObservingStrategy strategy = createTestInternetObservingStrategy();
+
+    // when
+    InternetObservingSettings settings = InternetObservingSettings
+        .initialInterval(initialInterval)
+        .interval(interval)
+        .host(host)
+        .port(port)
+        .timeout(timeout)
+        .errorHandler(testErrorHandler)
+        .strategy(strategy)
+        .build();
+
+    // then
+    Single<Boolean> single = ReactiveNetwork.checkInternetConnectivity(settings);
     assertThat(single).isNotNull();
+  }
+
+  @NonNull private InternetObservingStrategy createTestInternetObservingStrategy() {
+    return new InternetObservingStrategy() {
+      @Override public Observable<Boolean> observeInternetConnectivity(int initialIntervalInMs,
+          int intervalInMs, String host, int port, int timeoutInMs,
+          ErrorHandler errorHandler) {
+        return Observable.empty();
+      }
+
+      @Override public Single<Boolean> checkInternetConnectivity(String host, int port,
+          int timeoutInMs, ErrorHandler errorHandler) {
+        return Single.fromCallable(new Callable<Boolean>() {
+          @Override public Boolean call() {
+            return true;
+          }
+        });
+      }
+
+      @Override public String getDefaultPingHost() {
+        return null;
+      }
+    };
+  }
+
+  @NonNull private ErrorHandler createTestErrorHandler() {
+    return new ErrorHandler() {
+      @Override public void handleError(Exception exception, String message) {
+      }
+    };
+  }
+
+  @Test
+  public void shouldHaveJustSevenMethodsInPublicApi() {
+    // given
+    Class<? extends ReactiveNetwork> clazz = ReactiveNetwork.create().getClass();
+    final int predefinedNumberOfMethods = 9;
+    final int publicMethodsInApi = 7; // this number can be increased only in reasonable case
+
+    // when
+    Method[] methods = clazz.getMethods();
+
+    // then
+    assertThat(methods.length).isEqualTo(predefinedNumberOfMethods + publicMethodsInApi);
   }
 }

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettingsTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettingsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2018 Piotr Wittchen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pwittchen.reactivenetwork.library.rx2.internet.observing;
+
+import android.support.annotation.NonNull;
+import com.github.pwittchen.reactivenetwork.library.rx2.BuildConfig;
+import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.DefaultErrorHandler;
+import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.ErrorHandler;
+import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.strategy.SocketInternetObservingStrategy;
+import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.strategy.WalledGardenInternetObservingStrategy;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(RobolectricTestRunner.class) @Config(constants = BuildConfig.class)
+public class InternetObservingSettingsTest {
+
+  @Test
+  public void shouldCreateSettings() {
+    // when
+    InternetObservingSettings settings = InternetObservingSettings.create();
+
+    // then
+    assertThat(settings).isNotNull();
+  }
+
+  @Test
+  public void shouldBuildSettingsWithDefaultValues() {
+    // when
+    InternetObservingSettings settings = InternetObservingSettings.create();
+
+    // then
+    assertThat(settings.initialInterval()).isEqualTo(0);
+    assertThat(settings.interval()).isEqualTo(2000);
+    assertThat(settings.host()).isEqualTo("http://clients3.google.com/generate_204");
+    assertThat(settings.port()).isEqualTo(80);
+    assertThat(settings.timeout()).isEqualTo(2000);
+    assertThat(settings.errorHandler()).isInstanceOf(DefaultErrorHandler.class);
+    assertThat(settings.strategy()).isInstanceOf(WalledGardenInternetObservingStrategy.class);
+  }
+
+  @Test
+  public void shouldBuildSettings() {
+    // given
+    final int initialInterval = 1;
+    final int interval = 2;
+    final String host = "www.test.com";
+    int port = 90;
+    int timeout = 3;
+    ErrorHandler testErrorHandler = createTestErrorHandler();
+    SocketInternetObservingStrategy strategy = new SocketInternetObservingStrategy();
+
+    // when
+    InternetObservingSettings settings = InternetObservingSettings
+        .initialInterval(initialInterval)
+        .interval(interval)
+        .host(host)
+        .port(port)
+        .timeout(timeout)
+        .errorHandler(testErrorHandler)
+        .strategy(strategy)
+        .build();
+
+    // then
+    assertThat(settings.initialInterval()).isEqualTo(initialInterval);
+    assertThat(settings.interval()).isEqualTo(interval);
+    assertThat(settings.host()).isEqualTo(host);
+    assertThat(settings.port()).isEqualTo(port);
+    assertThat(settings.timeout()).isEqualTo(timeout);
+    assertThat(settings.errorHandler()).isNotNull();
+    assertThat(settings.errorHandler()).isNotInstanceOf(DefaultErrorHandler.class);
+    assertThat(settings.strategy()).isInstanceOf(SocketInternetObservingStrategy.class);
+  }
+
+  @NonNull private ErrorHandler createTestErrorHandler() {
+    return new ErrorHandler() {
+      @Override public void handleError(Exception exception, String message) {
+      }
+    };
+  }
+}


### PR DESCRIPTION
The following changes were applied (solves #271):
- introducing `InternetObservingSettings` with Builder pattern
- removing confusing methods with various multiple parameters in the `ReactiveNetwork` class (API-breaking changes)
- introducing new methods with Settings parameter, which can be constructed via new builder
- updating unit tests