### PR TITLE
Refactoring Connectivity class to better builder pattern (improving code consistency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ ReactiveNetwork.observeNetworkConnectivity(context)
     .subscribe(new Consumer<Connectivity>() {
       @Override public void accept(final Connectivity connectivity) {
         // do something with connectivity
-        // you can call connectivity.getState();
-        // connectivity.getType(); or connectivity.toString();
+        // you can call connectivity.state();
+        // connectivity.type(); or connectivity.toString();
       }
     });
 ```
@@ -107,17 +107,19 @@ This method allows you to apply your own network observing strategy and is used 
 Connectivity create()
 Connectivity create(Context context)
 
-NetworkInfo.State getState()
-NetworkInfo.DetailedState getDetailedState()
-int getType()
-int getSubType()
-boolean isAvailable()
-boolean isFailover()
-boolean isRoaming()
-String getTypeName()
-String getSubTypeName()
-String getReason()
-String getExtraInfo()
+NetworkInfo.State state()
+NetworkInfo.DetailedState detailedState()
+int type()
+int subType()
+boolean available()
+boolean failover()
+boolean roaming()
+String typeName()
+String subTypeName()
+String reason()
+String extraInfo()
+
+// and respective setters
 
 class Builder
 ```
@@ -316,7 +318,7 @@ Next, we can chain two streams:
 ReactiveNetwork
    .observeNetworkConnectivity(getApplicationContext())
    .flatMap(connectivity -> {
-     if (connectivity.getState() == NetworkInfo.State.CONNECTED) {
+     if (connectivity.state() == NetworkInfo.State.CONNECTED) {
        return getResponse("http://github.com");
      }
      return Observable.error(() -> new RuntimeException("not connected"));

--- a/app-kotlin/src/main/kotlin/com/github/pwittchen/reactivenetwork/kotlinapp/MainActivity.kt
+++ b/app-kotlin/src/main/kotlin/com/github/pwittchen/reactivenetwork/kotlinapp/MainActivity.kt
@@ -46,8 +46,8 @@ class MainActivity : Activity() {
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe { connectivity ->
           Log.d(TAG, connectivity.toString())
-          val state = connectivity.state
-          val name = connectivity.typeName
+          val state = connectivity.state()
+          val name = connectivity.typeName()
           connectivity_status.text = String.format("state: %s, typeName: %s", state, name)
         }
 

--- a/app/src/main/java/com/github/pwittchen/reactivenetwork/app/MainActivity.java
+++ b/app/src/main/java/com/github/pwittchen/reactivenetwork/app/MainActivity.java
@@ -47,8 +47,8 @@ public class MainActivity extends Activity {
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(connectivity -> {
           Log.d(TAG, connectivity.toString());
-          final NetworkInfo.State state = connectivity.getState();
-          final String name = connectivity.getTypeName();
+          final NetworkInfo.State state = connectivity.state();
+          final String name = connectivity.typeName();
           tvConnectivityStatus.setText(String.format("state: %s, typeName: %s", state, name));
         });
 

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/Connectivity.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/Connectivity.java
@@ -26,25 +26,30 @@ import android.support.annotation.NonNull;
 public class Connectivity {
   static final int UNKNOWN_TYPE = -1;
   static final int UNKNOWN_SUB_TYPE = -1;
-  private NetworkInfo.State state;
-  private NetworkInfo.DetailedState detailedState;
-  private int type;
-  private int subType;
-  private boolean available;
-  private boolean failover;
-  private boolean roaming;
-  private String typeName;
-  private String subTypeName;
-  private String reason;
-  private String extraInfo;
+  private NetworkInfo.State state; // NOPMD
+  private NetworkInfo.DetailedState detailedState; // NOPMD
+  private int type; // NOPMD
+  private int subType; // NOPMD
+  private boolean available; // NOPMD
+  private boolean failover; // NOPMD
+  private boolean roaming; // NOPMD
+  private String typeName; // NOPMD
+  private String subTypeName; // NOPMD
+  private String reason; // NOPMD
+  private String extraInfo; // NOPMD
 
   public static Connectivity create() {
-    return new Builder().build();
+    return builder().build();
   }
 
   public static Connectivity create(@NonNull Context context) {
     Preconditions.checkNotNull(context, "context == null");
     return create(context, getConnectivityManager(context));
+  }
+
+  private static ConnectivityManager getConnectivityManager(Context context) {
+    final String service = Context.CONNECTIVITY_SERVICE;
+    return (ConnectivityManager) context.getSystemService(service);
   }
 
   protected static Connectivity create(@NonNull Context context, ConnectivityManager manager) {
@@ -59,7 +64,8 @@ public class Connectivity {
   }
 
   private static Connectivity create(NetworkInfo networkInfo) {
-    return new Builder().state(networkInfo.getState())
+    return new Builder()
+        .state(networkInfo.getState())
         .detailedState(networkInfo.getDetailedState())
         .type(networkInfo.getType())
         .subType(networkInfo.getSubtype())
@@ -73,21 +79,7 @@ public class Connectivity {
         .build();
   }
 
-  protected Connectivity() {
-    this.state = NetworkInfo.State.DISCONNECTED; // NOPMD
-    this.detailedState = NetworkInfo.DetailedState.IDLE; // NOPMD
-    this.type = UNKNOWN_TYPE; // NOPMD
-    this.subType = UNKNOWN_SUB_TYPE; // NOPMD
-    this.available = false; // NOPMD
-    this.failover = false; // NOPMD
-    this.roaming = false; // NOPMD
-    this.typeName = "NONE"; // NOPMD
-    this.subTypeName = "NONE"; // NOPMD
-    this.reason = ""; // NOPMD
-    this.extraInfo = ""; // NOPMD
-  }
-
-  protected Connectivity(Builder builder) {
+  private Connectivity(Builder builder) {
     state = builder.state;
     detailedState = builder.detailedState;
     type = builder.type;
@@ -101,53 +93,100 @@ public class Connectivity {
     extraInfo = builder.extraInfo;
   }
 
-  private static ConnectivityManager getConnectivityManager(Context context) {
-    final String service = Context.CONNECTIVITY_SERVICE;
-    return (ConnectivityManager) context.getSystemService(service);
+  private Connectivity() {
+    this(builder());
   }
 
-  public NetworkInfo.State getState() {
+  private static Builder builder() {
+    return new Connectivity.Builder();
+  }
+
+  public NetworkInfo.State state() {
     return state;
   }
 
-  public NetworkInfo.DetailedState getDetailedState() {
+  public static Builder state(NetworkInfo.State state) {
+    return builder().state(state);
+  }
+
+  public NetworkInfo.DetailedState detailedState() {
     return detailedState;
   }
 
-  public int getType() {
+  public static Builder state(NetworkInfo.DetailedState detailedState) {
+    return builder().detailedState(detailedState);
+  }
+
+  public int type() {
     return type;
   }
 
-  public int getSubType() {
+  public static Builder type(int type) {
+    return builder().type(type);
+  }
+
+  public int subType() {
     return subType;
   }
 
-  public boolean isAvailable() {
+  public static Builder subType(int subType) {
+    return builder().subType(subType);
+  }
+
+  public boolean available() {
     return available;
   }
 
-  public boolean isFailover() {
+  public static Builder available(boolean available) {
+    return builder().available(available);
+  }
+
+  public boolean failover() {
     return failover;
   }
 
-  public boolean isRoaming() {
+  public static Builder failover(boolean failover) {
+    return builder().failover(failover);
+  }
+
+  public boolean roaming() {
     return roaming;
   }
 
-  public String getTypeName() {
+  public static Builder roaming(boolean roaming) {
+    return builder().roaming(roaming);
+  }
+
+  public String typeName() {
     return typeName;
   }
 
-  public String getSubTypeName() {
+  public static Builder typeName(String typeName) {
+    return builder().typeName(typeName);
+  }
+
+  public String subTypeName() {
     return subTypeName;
   }
 
-  public String getReason() {
+  public static Builder subTypeName(String subTypeName) {
+    return builder().subTypeName(subTypeName);
+  }
+
+  public String reason() {
     return reason;
   }
 
-  public String getExtraInfo() {
+  public static Builder reason(String reason) {
+    return builder().reason(reason);
+  }
+
+  public String extraInfo() {
     return extraInfo;
+  }
+
+  public static Builder extraInfo(String extraInfo) {
+    return builder().extraInfo(extraInfo);
   }
 
   @Override public boolean equals(Object o) {

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/ConnectivityPredicate.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/ConnectivityPredicate.java
@@ -39,7 +39,7 @@ public class ConnectivityPredicate {
     return new Predicate<Connectivity>() {
       @Override public boolean test(@NonNull Connectivity connectivity) throws Exception {
         for (NetworkInfo.State state : states) {
-          if (connectivity.getState() == state) {
+          if (connectivity.state() == state) {
             return true;
           }
         }
@@ -59,7 +59,7 @@ public class ConnectivityPredicate {
     return new Predicate<Connectivity>() {
       @Override public boolean test(@NonNull Connectivity connectivity) throws Exception {
         for (int type : extendedTypes) {
-          if (connectivity.getType() == type) {
+          if (connectivity.type() == type) {
             return true;
           }
         }

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettings.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettings.java
@@ -49,7 +49,7 @@ public final class InternetObservingSettings {
    * @return settings with default parameters
    */
   public static InternetObservingSettings create() {
-    return new InternetObservingSettings.Builder().build();
+    return new Builder().build();
   }
 
   private InternetObservingSettings(Builder builder) {

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ConnectivityTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ConnectivityTest.java
@@ -35,21 +35,21 @@ import static com.google.common.truth.Truth.assertThat;
 
   @Test public void shouldCreateConnectivity() {
     // when
-    Connectivity connectivity = new Connectivity();
+    Connectivity connectivity = Connectivity.create();
 
     // then
     assertThat(connectivity).isNotNull();
-    assertThat(connectivity.getState()).isEqualTo(NetworkInfo.State.DISCONNECTED);
-    assertThat(connectivity.getDetailedState()).isEqualTo(NetworkInfo.DetailedState.IDLE);
-    assertThat(connectivity.getType()).isEqualTo(Connectivity.UNKNOWN_TYPE);
-    assertThat(connectivity.getSubType()).isEqualTo(Connectivity.UNKNOWN_SUB_TYPE);
-    assertThat(connectivity.isAvailable()).isFalse();
-    assertThat(connectivity.isFailover()).isFalse();
-    assertThat(connectivity.isRoaming()).isFalse();
-    assertThat(connectivity.getTypeName()).isEqualTo(TYPE_NAME_NONE);
-    assertThat(connectivity.getSubTypeName()).isEqualTo(TYPE_NAME_NONE);
-    assertThat(connectivity.getReason()).isEmpty();
-    assertThat(connectivity.getExtraInfo()).isEmpty();
+    assertThat(connectivity.state()).isEqualTo(NetworkInfo.State.DISCONNECTED);
+    assertThat(connectivity.detailedState()).isEqualTo(NetworkInfo.DetailedState.IDLE);
+    assertThat(connectivity.type()).isEqualTo(Connectivity.UNKNOWN_TYPE);
+    assertThat(connectivity.subType()).isEqualTo(Connectivity.UNKNOWN_SUB_TYPE);
+    assertThat(connectivity.available()).isFalse();
+    assertThat(connectivity.failover()).isFalse();
+    assertThat(connectivity.roaming()).isFalse();
+    assertThat(connectivity.typeName()).isEqualTo(TYPE_NAME_NONE);
+    assertThat(connectivity.subTypeName()).isEqualTo(TYPE_NAME_NONE);
+    assertThat(connectivity.reason()).isEmpty();
+    assertThat(connectivity.extraInfo()).isEmpty();
   }
 
   @Test public void stateShouldBeEqualToGivenValue() throws Exception {
@@ -60,7 +60,7 @@ import static com.google.common.truth.Truth.assertThat;
         .build();
 
     // when
-    final Predicate<Connectivity> equalTo = ConnectivityPredicate.hasState(connectivity.getState());
+    final Predicate<Connectivity> equalTo = ConnectivityPredicate.hasState(connectivity.state());
     final Boolean shouldBeEqualToGivenStatus = equalTo.test(connectivity);
 
     // then
@@ -110,7 +110,7 @@ import static com.google.common.truth.Truth.assertThat;
         .build();
 
     // note that unknown type is added initially by the ConnectivityPredicate#hasType method
-    final int givenTypes[] = { connectivity.getType(), Connectivity.UNKNOWN_TYPE };
+    final int givenTypes[] = { connectivity.type(), Connectivity.UNKNOWN_TYPE };
 
     // when
     final Predicate<Connectivity> equalTo = ConnectivityPredicate.hasType(givenTypes);
@@ -269,17 +269,17 @@ import static com.google.common.truth.Truth.assertThat;
         .build();
 
     // then
-    assertThat(connectivity.getState()).isEqualTo(state);
-    assertThat(connectivity.getDetailedState()).isEqualTo(detailedState);
-    assertThat(connectivity.getType()).isEqualTo(type);
-    assertThat(connectivity.getSubType()).isEqualTo(subType);
-    assertThat(connectivity.isAvailable()).isTrue();
-    assertThat(connectivity.isFailover()).isFalse();
-    assertThat(connectivity.isRoaming()).isTrue();
-    assertThat(connectivity.getTypeName()).isEqualTo(typeName);
-    assertThat(connectivity.getSubTypeName()).isEqualTo(subTypeName);
-    assertThat(connectivity.getReason()).isEqualTo(reason);
-    assertThat(connectivity.getExtraInfo()).isEqualTo(extraInfo);
+    assertThat(connectivity.state()).isEqualTo(state);
+    assertThat(connectivity.detailedState()).isEqualTo(detailedState);
+    assertThat(connectivity.type()).isEqualTo(type);
+    assertThat(connectivity.subType()).isEqualTo(subType);
+    assertThat(connectivity.available()).isTrue();
+    assertThat(connectivity.failover()).isFalse();
+    assertThat(connectivity.roaming()).isTrue();
+    assertThat(connectivity.typeName()).isEqualTo(typeName);
+    assertThat(connectivity.subTypeName()).isEqualTo(subTypeName);
+    assertThat(connectivity.reason()).isEqualTo(reason);
+    assertThat(connectivity.extraInfo()).isEqualTo(extraInfo);
   }
 
   @Test public void connectivityShouldNotBeEqualToAnotherOne() {
@@ -326,16 +326,16 @@ import static com.google.common.truth.Truth.assertThat;
     Connectivity connectivity = Connectivity.create(context, connectivityManager);
 
     // then
-    assertThat(connectivity.getType()).isEqualTo(Connectivity.UNKNOWN_TYPE);
-    assertThat(connectivity.getSubType()).isEqualTo(Connectivity.UNKNOWN_SUB_TYPE);
-    assertThat(connectivity.getState()).isEqualTo(NetworkInfo.State.DISCONNECTED);
-    assertThat(connectivity.getDetailedState()).isEqualTo(NetworkInfo.DetailedState.IDLE);
-    assertThat(connectivity.isAvailable()).isFalse();
-    assertThat(connectivity.isFailover()).isFalse();
-    assertThat(connectivity.isRoaming()).isFalse();
-    assertThat(connectivity.getTypeName()).isEqualTo(TYPE_NAME_NONE);
-    assertThat(connectivity.getSubTypeName()).isEqualTo(TYPE_NAME_NONE);
-    assertThat(connectivity.getReason()).isEmpty();
-    assertThat(connectivity.getExtraInfo()).isEmpty();
+    assertThat(connectivity.type()).isEqualTo(Connectivity.UNKNOWN_TYPE);
+    assertThat(connectivity.subType()).isEqualTo(Connectivity.UNKNOWN_SUB_TYPE);
+    assertThat(connectivity.state()).isEqualTo(NetworkInfo.State.DISCONNECTED);
+    assertThat(connectivity.detailedState()).isEqualTo(NetworkInfo.DetailedState.IDLE);
+    assertThat(connectivity.available()).isFalse();
+    assertThat(connectivity.failover()).isFalse();
+    assertThat(connectivity.roaming()).isFalse();
+    assertThat(connectivity.typeName()).isEqualTo(TYPE_NAME_NONE);
+    assertThat(connectivity.subTypeName()).isEqualTo(TYPE_NAME_NONE);
+    assertThat(connectivity.reason()).isEmpty();
+    assertThat(connectivity.extraInfo()).isEmpty();
   }
 }

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetworkTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetworkTest.java
@@ -116,7 +116,7 @@ import static com.google.common.truth.Truth.assertThat;
     Connectivity connectivity = ReactiveNetwork.observeNetworkConnectivity(context).blockingFirst();
 
     // then
-    assertThat(connectivity.getState()).isEqualTo(NetworkInfo.State.CONNECTED);
+    assertThat(connectivity.state()).isEqualTo(NetworkInfo.State.CONNECTED);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/NetworkObservingStrategyTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/NetworkObservingStrategyTest.java
@@ -58,7 +58,7 @@ import static com.google.common.truth.Truth.assertThat;
     strategy.observeNetworkConnectivity(context).subscribe(new Consumer<Connectivity>() {
       @Override public void accept(Connectivity connectivity) throws Exception {
         // then
-        assertThat(connectivity.getState()).isEqualTo(NetworkInfo.State.CONNECTED);
+        assertThat(connectivity.state()).isEqualTo(NetworkInfo.State.CONNECTED);
       }
     });
   }

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/LollipopNetworkObservingStrategyTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/LollipopNetworkObservingStrategyTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.verify;
     Connectivity connectivity = strategy.observeNetworkConnectivity(context).blockingFirst();
 
     // then
-    assertThat(connectivity.getState()).isEqualTo(NetworkInfo.State.CONNECTED);
+    assertThat(connectivity.state()).isEqualTo(NetworkInfo.State.CONNECTED);
   }
 
   @Test public void shouldStopObservingConnectivity() {

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/MarshmallowNetworkObservingStrategyTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/MarshmallowNetworkObservingStrategyTest.java
@@ -75,7 +75,7 @@ import static org.mockito.Mockito.when;
     Connectivity connectivity = strategy.observeNetworkConnectivity(context).blockingFirst();
 
     // then
-    assertThat(connectivity.getState()).isEqualTo(NetworkInfo.State.CONNECTED);
+    assertThat(connectivity.state()).isEqualTo(NetworkInfo.State.CONNECTED);
   }
 
   @Test public void shouldStopObservingConnectivity() {

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/PreLollipopNetworkObservingStrategyTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/PreLollipopNetworkObservingStrategyTest.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.verify;
     strategy.observeNetworkConnectivity(context).subscribe(new Consumer<Connectivity>() {
       @Override public void accept(Connectivity connectivity) throws Exception {
         // then
-        assertThat(connectivity.getState()).isEqualTo(NetworkInfo.State.CONNECTED);
+        assertThat(connectivity.state()).isEqualTo(NetworkInfo.State.CONNECTED);
       }
     });
   }


### PR DESCRIPTION
solves #281

Now Builder pattern in `Connectivity` class is designed in the same way as in the `InternetObservingSettings` class.

**Note**: 

this update will break the API of `Connectivity` class and will require bumping major library version.