### PR TITLE
Migrate support lib dependencies to AndroidX.

### DIFF
--- a/app-kotlin/build.gradle
+++ b/app-kotlin/build.gradle
@@ -53,7 +53,8 @@ ktlint {
 dependencies {
   implementation project(':library')
   implementation deps.kotlinstdlib
-  implementation deps.appcompatv7
+  implementation deps.annotation
+  implementation deps.appcompat
 }
 
 buildscript {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
   implementation project(':library')
-  implementation deps.appcompatv7
+  implementation deps.appcompat
 }
 
 buildscript {

--- a/build.gradle
+++ b/build.gradle
@@ -8,14 +8,14 @@ ext {
   compileSdkVersion = 28
   buildToolsVersion = '28.0.3'
   gradleVersion = '4.6'
-  kotlinVersion = '1.2.70'
+  kotlinVersion = '1.3.31'
   detektVersion = '1.0.0.RC6-1'
 }
 
-ext.deps = [rxjava2           : 'io.reactivex.rxjava2:rxjava:2.2.4',
-            rxandroid2        : 'io.reactivex.rxjava2:rxandroid:2.1.0',
-            supportannotations: 'com.android.support:support-annotations:28.0.0',
-            appcompatv7       : 'com.android.support:appcompat-v7:28.0.0',
+ext.deps = [rxjava2           : 'io.reactivex.rxjava2:rxjava:2.2.8',
+            rxandroid2        : 'io.reactivex.rxjava2:rxandroid:2.1.1',
+            annotation        : 'androidx.annotation:annotation:1.0.2',
+            appcompat         : 'androidx.appcompat:appcompat:1.0.2',
             junit             : 'junit:junit:4.12',
             truth             : 'com.google.truth:truth:0.42',
             robolectric       : 'org.robolectric:robolectric:4.1',

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -52,7 +52,7 @@ jacocoAndroidUnitTestReport {
 dependencies {
   api deps.rxjava2
   api deps.rxandroid2
-  implementation deps.supportannotations
+  implementation deps.annotation
 
   testImplementation deps.junit
   testImplementation deps.truth

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/Connectivity.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/Connectivity.java
@@ -18,7 +18,7 @@ package com.github.pwittchen.reactivenetwork.library.rx2;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Connectivity class represents current connectivity status. It wraps NetworkInfo object.

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetwork.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetwork.java
@@ -17,7 +17,7 @@ package com.github.pwittchen.reactivenetwork.library.rx2;
 
 import android.Manifest;
 import android.content.Context;
-import android.support.annotation.RequiresPermission;
+import androidx.annotation.RequiresPermission;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.InternetObservingSettings;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.InternetObservingStrategy;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.ErrorHandler;

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/MarshmallowNetworkObservingStrategy.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/MarshmallowNetworkObservingStrategy.java
@@ -25,7 +25,7 @@ import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.net.NetworkRequest;
 import android.os.PowerManager;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 import com.github.pwittchen.reactivenetwork.library.rx2.Connectivity;
 import com.github.pwittchen.reactivenetwork.library.rx2.network.observing.NetworkObservingStrategy;

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetworkTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetworkTest.java
@@ -18,7 +18,7 @@ package com.github.pwittchen.reactivenetwork.library.rx2;
 import android.app.Application;
 import android.content.Context;
 import android.net.NetworkInfo;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.InternetObservingSettings;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.InternetObservingStrategy;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.DefaultErrorHandler;

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettingsTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettingsTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.pwittchen.reactivenetwork.library.rx2.internet.observing;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.DefaultErrorHandler;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.error.ErrorHandler;
 import com.github.pwittchen.reactivenetwork.library.rx2.internet.observing.strategy.SocketInternetObservingStrategy;


### PR DESCRIPTION
Closes #331
 
PR migrates support lib to AndroidX:

`com.android.support:support-annotations:28.0.0 -> androidx.annotation:annotation:1.0.2`
`com.android.support:appcompat-v7:28.0.0 -> androidx.appcompat:appcompat:1.0.2`

Note that the library itself only depends on the **annotation** library, **appcompat** is used by sample app.

The following have also been updated:
 
- Kotlin 1.3.31
- RxJava 2.2.8
- RxAndroid 2.1.1