### PR TITLE
fix:MIUI 10.3.6 android 9.0 MI8.  switch wifi to mobile doesn't response

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
 
     <application
         android:allowBackup="true"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Jan 02 23:46:18 CST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/MarshmallowNetworkObservingStrategy.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/MarshmallowNetworkObservingStrategy.java
@@ -77,7 +77,7 @@ import static com.github.pwittchen.reactivenetwork.library.rx2.ReactiveNetwork.L
             .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED)
             .build();
 
-    manager.registerNetworkCallback(request, networkCallback);
+    manager.requestNetwork(request, networkCallback);
 
     return connectivitySubject.toFlowable(BackpressureStrategy.LATEST).doOnCancel(new Action() {
       @Override public void run() {


### PR DESCRIPTION
This PR introduces the following update:

[briefly describe your update, e.g. closes specified issue, fixes a bug, adds new unit test, etc.]
On my phone.
MOBILE: MIUI 10.3.6 
PLATFORM: android 9

    implementation 'com.github.pwittchen:reactivenetwork-rx2:3.0.6'

switch wifi to mobile doesn't response.

I find that.:#330 but wont fix on my phone. 

