### PR TITLE
Changing protocol from https to http in WalledGardenInternetObservingStrategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,12 @@
 apply plugin: 'io.codearte.nexus-staging'
 
 ext {
-  minSdkVersion = 9
+  minSdkVersion = 14
   minSdkVersionApps = 23
   compileSdkVersion = 28
   buildToolsVersion = '28.0.3'
   gradleVersion = '4.6'
-  kotlinVersion = '1.3.70'
+  kotlinVersion = '1.3.71'
   detektVersion = '1.0.0.RC6-1'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@ org.gradle.jvmargs=-XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled -XX:+Heap
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8.fullMode=false
+android.enableUnitTestBinaryResources=true

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -47,6 +47,8 @@ android {
     }
   }
 
+  testOptions.unitTests.includeAndroidResources = true
+
   jacocoAndroidUnitTestReport {
     csv.enabled false
     html.enabled true

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettings.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettings.java
@@ -131,7 +131,7 @@ public final class InternetObservingSettings {
   public final static class Builder {
     private int initialInterval = 0;
     private int interval = 2000;
-    private String host = "https://clients3.google.com/generate_204";
+    private String host = "http://clients3.google.com/generate_204";
     private int port = 80;
     private int timeout = 2000;
     private int httpResponse = HttpURLConnection.HTTP_NO_CONTENT;

--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/strategy/WalledGardenInternetObservingStrategy.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/strategy/WalledGardenInternetObservingStrategy.java
@@ -40,7 +40,7 @@ import javax.net.ssl.HttpsURLConnection;
  * if a device is connected to the Internet or not.
  */
 @Open public class WalledGardenInternetObservingStrategy implements InternetObservingStrategy {
-  private static final String DEFAULT_HOST = "https://clients3.google.com/generate_204";
+  private static final String DEFAULT_HOST = "http://clients3.google.com/generate_204";
   private static final String HTTP_PROTOCOL = "http://";
   private static final String HTTPS_PROTOCOL = "https://";
 

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettingsTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettingsTest.java
@@ -46,7 +46,7 @@ public class InternetObservingSettingsTest {
     // then
     assertThat(settings.initialInterval()).isEqualTo(0);
     assertThat(settings.interval()).isEqualTo(2000);
-    assertThat(settings.host()).isEqualTo("https://clients3.google.com/generate_204");
+    assertThat(settings.host()).isEqualTo("http://clients3.google.com/generate_204");
     assertThat(settings.port()).isEqualTo(80);
     assertThat(settings.timeout()).isEqualTo(2000);
     assertThat(settings.httpResponse()).isEqualTo(204);

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/strategy/WalledGardenInternetObservingStrategyTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/strategy/WalledGardenInternetObservingStrategyTest.java
@@ -160,7 +160,7 @@ import static org.mockito.Mockito.when;
 
     // when
     HttpURLConnection connection =
-        strategy.createHttpsUrlConnection(getHost(), PORT, TIMEOUT_IN_MS);
+        strategy.createHttpsUrlConnection("https://clients3.google.com", PORT, TIMEOUT_IN_MS);
 
     // then
     assertThat(connection).isNotNull();
@@ -176,7 +176,7 @@ import static org.mockito.Mockito.when;
     // given
     final String errorMsg = "Could not establish connection with WalledGardenStrategy";
     final IOException givenException = new IOException(errorMsg);
-    when(strategy.createHttpsUrlConnection(getHost(), PORT, TIMEOUT_IN_MS)).thenThrow(
+    when(strategy.createHttpUrlConnection(getHost(), PORT, TIMEOUT_IN_MS)).thenThrow(
         givenException);
 
     // when


### PR DESCRIPTION
WalledGardenInternetObservingStrategy, it stopped working correctly for default host and changing port didn't help - fixes #422 and #415
