### PR TITLE
Changed to not use NetworkInfo class for Lollipop and above

### DIFF
--- a/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/info/NetworkState.java
+++ b/library/src/main/java/com/github/pwittchen/reactivenetwork/library/rx2/info/NetworkState.java
@@ -1,0 +1,47 @@
+package com.github.pwittchen.reactivenetwork.library.rx2.info;
+
+import android.net.LinkProperties;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+
+/**
+ * NetworkState data object
+ */
+public class NetworkState {
+    private boolean isConnected = false;
+    private Network network = null;
+    private NetworkCapabilities networkCapabilities = null;
+    private LinkProperties linkProperties = null;
+
+    public boolean isConnected() {
+        return isConnected;
+    }
+
+    public void setConnected(boolean connected) {
+        isConnected = connected;
+    }
+
+    public Network getNetwork() {
+        return network;
+    }
+
+    public void setNetwork(Network network) {
+        this.network = network;
+    }
+
+    public NetworkCapabilities getNetworkCapabilities() {
+        return networkCapabilities;
+    }
+
+    public void setNetworkCapabilities(NetworkCapabilities networkCapabilities) {
+        this.networkCapabilities = networkCapabilities;
+    }
+
+    public LinkProperties getLinkProperties() {
+        return linkProperties;
+    }
+
+    public void setLinkProperties(LinkProperties linkProperties) {
+        this.linkProperties = linkProperties;
+    }
+}


### PR DESCRIPTION
This PR introduces the following update:

Was concerned about issue #318 

However I couldn't completely remove the NetworkInfo class in Connectivity class

I just changed it so that it would use the network callback api from Lollipop and above.

If you don't have time please give me some tips on how I should implement it or just dump in ideas in this PR.

I will try to work on it. 

Hope to hear from you soon.