### PR TITLE
fixing unit (robolectric) tests on Linux and Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /.DS_Store
 /build
 *.iml
-.gradletasknamecache
+.gradletasknamecach
+*.exec

--- a/app-kotlin/build.gradle
+++ b/app-kotlin/build.gradle
@@ -55,7 +55,6 @@ dependencies {
 buildscript {
   repositories {
     mavenCentral()
-    jcenter()
     google()
     maven {
       url 'https://plugins.gradle.org/m2/'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,6 @@ dependencies {
 buildscript {
   repositories {
     mavenCentral()
-    jcenter()
     google()
     maven {
       url 'https://plugins.gradle.org/m2/'

--- a/build.gradle
+++ b/build.gradle
@@ -5,20 +5,20 @@ apply plugin: 'io.codearte.nexus-staging'
 ext {
   minSdkVersion = 14
   minSdkVersionApps = 23
-  compileSdkVersion = 28
+  compileSdkVersion = 29
   buildToolsVersion = '28.0.3'
   gradleVersion = '4.6'
   kotlinVersion = '1.4.0'
   detektVersion = '1.0.0.RC6-1'
 }
 
-ext.deps = [rxjava2           : 'io.reactivex.rxjava2:rxjava:2.2.19',
+ext.deps = [rxjava2           : 'io.reactivex.rxjava2:rxjava:2.2.21',
             rxandroid2        : 'io.reactivex.rxjava2:rxandroid:2.1.1',
             annotation        : 'androidx.annotation:annotation:1.1.0',
             appcompat         : 'androidx.appcompat:appcompat:1.2.0',
             junit             : 'junit:junit:4.13',
             truth             : 'com.google.truth:truth:1.0.1',
-            robolectric       : 'org.robolectric:robolectric:4.3.1',
+            robolectric       : 'org.robolectric:robolectric:4.9',
             mockitocore       : 'org.mockito:mockito-core:3.5.2',
             nullaway          : 'com.uber.nullaway:nullaway:0.8.0',
             errorprone        : 'com.google.errorprone:error_prone_core:2.3.4',
@@ -31,14 +31,13 @@ ext.deps = [rxjava2           : 'io.reactivex.rxjava2:rxjava:2.2.19',
 buildscript {
   repositories {
     google()
-    jcenter()
     mavenCentral()
     maven {
       url 'https://plugins.gradle.org/m2/'
     }
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.6.3'
+    classpath 'com.android.tools.build:gradle:3.6.4'
     classpath('com.hiya:jacoco-android:0.2') {
       exclude group: 'org.codehaus.groovy', module: 'groovy-all'
     }
@@ -54,7 +53,6 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
     mavenCentral()
     maven {
       url 'https://plugins.gradle.org/m2/'

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,6 @@ org.gradle.jvmargs=-XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled -XX:+Heap
 
 android.useAndroidX=true
 android.enableJetifier=true
+android.jetifier.blacklist=bcprov-jdk15on
 android.enableR8.fullMode=false
 android.enableUnitTestBinaryResources=true

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -49,6 +49,7 @@ android {
       jacoco {
         includeNoLocationClasses = true
       }
+      systemProperty 'robolectric.dependency.repo.url', 'https://repo1.maven.org/maven2'
     }
   }
 
@@ -65,6 +66,7 @@ android {
     api deps.rxandroid2
     implementation deps.annotation
 
+    testImplementation project(path: ':library')
     testImplementation deps.junit
     testImplementation deps.truth
     testImplementation deps.robolectric
@@ -92,5 +94,6 @@ android {
 
   tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
   }
 }

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ConnectivityTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ConnectivityTest.java
@@ -73,6 +73,7 @@ import static com.google.common.truth.Truth.assertThat;
         .typeName(TYPE_NAME_WIFI)
         .build();
 
+    //noinspection CStyleArrayDeclaration
     final NetworkInfo.State states[] =
         { NetworkInfo.State.CONNECTED, NetworkInfo.State.CONNECTING };
 
@@ -109,6 +110,7 @@ import static com.google.common.truth.Truth.assertThat;
         .build();
 
     // note that unknown type is added initially by the ConnectivityPredicate#hasType method
+    //noinspection CStyleArrayDeclaration
     final int givenTypes[] = { connectivity.type(), Connectivity.UNKNOWN_TYPE };
 
     // when
@@ -127,6 +129,7 @@ import static com.google.common.truth.Truth.assertThat;
         .build();
 
     // note that unknown type is added initially by the ConnectivityPredicate#hasType method
+    //noinspection CStyleArrayDeclaration
     final int givenTypes[] = {
         ConnectivityManager.TYPE_WIFI, ConnectivityManager.TYPE_MOBILE, Connectivity.UNKNOWN_TYPE
     };
@@ -147,6 +150,7 @@ import static com.google.common.truth.Truth.assertThat;
         .build();
 
     // note that unknown type is added initially by the ConnectivityPredicate#hasType method
+    //noinspection CStyleArrayDeclaration
     final int givenTypes[] = { ConnectivityManager.TYPE_MOBILE, Connectivity.UNKNOWN_TYPE };
 
     // when
@@ -163,6 +167,7 @@ import static com.google.common.truth.Truth.assertThat;
     final Context context = null;
 
     // when
+    //noinspection ConstantConditions
     Connectivity.create(context);
 
     // then
@@ -318,10 +323,11 @@ import static com.google.common.truth.Truth.assertThat;
 
   @Test public void shouldCreateDefaultConnectivityWhenConnectivityManagerIsNull() {
     // given
-    final Context context = RuntimeEnvironment.application.getApplicationContext();
+    final Context context = RuntimeEnvironment.getApplication().getApplicationContext();
     final ConnectivityManager connectivityManager = null;
 
     // when
+    @SuppressWarnings("ConstantConditions")
     Connectivity connectivity = Connectivity.create(context, connectivityManager);
 
     // then

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetworkTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/ReactiveNetworkTest.java
@@ -29,16 +29,17 @@ import com.github.pwittchen.reactivenetwork.library.rx2.network.observing.strate
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import java.lang.reflect.Method;
-import java.util.concurrent.Callable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowConnectivityManager;
 
 import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(shadows = ShadowConnectivityManager.class)
 @SuppressWarnings("NullAway") public class ReactiveNetworkTest {
 
   private static final String TEST_VALID_HOST = "www.test.com";
@@ -75,7 +76,11 @@ import static com.google.common.truth.Truth.assertThat;
 
   private void networkConnectivityObservableShouldNotBeNull() {
     // given
-    final Context context = RuntimeEnvironment.application;
+    final Application context = RuntimeEnvironment.getApplication();
+    //final ConnectivityManager connectivityManagerMock = (ConnectivityManager) context
+    //    .getSystemService(Context.CONNECTIVITY_SERVICE);
+    //
+    //shadowOf(connectivityManagerMock);
 
     // when
     Observable<Connectivity> observable;
@@ -87,7 +92,8 @@ import static com.google.common.truth.Truth.assertThat;
 
   @Test public void observeNetworkConnectivityWithStrategyShouldNotBeNull() {
     // given
-    final Context context = RuntimeEnvironment.application;
+    final Application context = RuntimeEnvironment.getApplication();
+
     NetworkObservingStrategy strategy = new LollipopNetworkObservingStrategy();
 
     // when
@@ -111,7 +117,7 @@ import static com.google.common.truth.Truth.assertThat;
 
   @Test public void observeNetworkConnectivityShouldBeConnectedOnStartWhenNetworkIsAvailable() {
     // given
-    final Application context = RuntimeEnvironment.application;
+    final Application context = RuntimeEnvironment.getApplication();
 
     // when
     Connectivity connectivity = ReactiveNetwork.observeNetworkConnectivity(context).blockingFirst();
@@ -127,6 +133,7 @@ import static com.google.common.truth.Truth.assertThat;
     final NetworkObservingStrategy strategy = new LollipopNetworkObservingStrategy();
 
     // when
+    //noinspection ConstantConditions
     ReactiveNetwork.observeNetworkConnectivity(context, strategy);
 
     // then an exception is thrown
@@ -151,6 +158,7 @@ import static com.google.common.truth.Truth.assertThat;
     final ErrorHandler errorHandler = new DefaultErrorHandler();
 
     // when
+    //noinspection ConstantConditions
     ReactiveNetwork.observeInternetConnectivity(strategy, TEST_VALID_INITIAL_INTERVAL,
         TEST_VALID_INTERVAL, TEST_VALID_HOST, TEST_VALID_PORT, TEST_VALID_TIMEOUT,
         TEST_VALID_HTTP_RESPONSE, errorHandler);
@@ -265,11 +273,7 @@ import static com.google.common.truth.Truth.assertThat;
 
       @Override public Single<Boolean> checkInternetConnectivity(String host, int port,
           int timeoutInMs, int httpResponse, ErrorHandler errorHandler) {
-        return Single.fromCallable(new Callable<Boolean>() {
-          @Override public Boolean call() {
-            return true;
-          }
-        });
+        return Single.fromCallable(() -> true);
       }
 
       @Override public String getDefaultPingHost() {
@@ -279,9 +283,7 @@ import static com.google.common.truth.Truth.assertThat;
   }
 
   @NonNull private ErrorHandler createTestErrorHandler() {
-    return new ErrorHandler() {
-      @Override public void handleError(Exception exception, String message) {
-      }
+    return (exception, message) -> {
     };
   }
 

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettingsTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/internet/observing/InternetObservingSettingsTest.java
@@ -91,9 +91,6 @@ public class InternetObservingSettingsTest {
   }
 
   @NonNull private ErrorHandler createTestErrorHandler() {
-    return new ErrorHandler() {
-      @Override public void handleError(Exception exception, String message) {
-      }
-    };
+    return (exception, message) -> { };
   }
 }

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/NetworkObservingStrategyTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/NetworkObservingStrategyTest.java
@@ -15,17 +15,17 @@
  */
 package com.github.pwittchen.reactivenetwork.library.rx2.network.observing;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.NetworkInfo;
 import com.github.pwittchen.reactivenetwork.library.rx2.Connectivity;
 import com.github.pwittchen.reactivenetwork.library.rx2.network.observing.strategy.LollipopNetworkObservingStrategy;
 import com.github.pwittchen.reactivenetwork.library.rx2.network.observing.strategy.PreLollipopNetworkObservingStrategy;
-import io.reactivex.functions.Consumer;
+import io.reactivex.disposables.Disposable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-
 import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
@@ -47,17 +47,19 @@ import static com.google.common.truth.Truth.assertThat;
     assertThatIsConnected(strategy);
   }
 
-  @SuppressWarnings("CheckReturnValue")
+  @SuppressLint("CheckResult")
   private void assertThatIsConnected(NetworkObservingStrategy strategy) {
     // given
-    final Context context = RuntimeEnvironment.application.getApplicationContext();
+    final Context context = RuntimeEnvironment.getApplication().getApplicationContext();
 
     //when
-    strategy.observeNetworkConnectivity(context).subscribe(new Consumer<Connectivity>() {
-      @Override public void accept(Connectivity connectivity) throws Exception {
-        // then
-        assertThat(connectivity.state()).isEqualTo(NetworkInfo.State.CONNECTED);
-      }
-    });
+    Disposable disposable = strategy.observeNetworkConnectivity(context)
+        .subscribe(
+            (@SuppressLint("CheckResult") Connectivity connectivity) -> {
+              // then
+              assertThat(connectivity.state()).isEqualTo(NetworkInfo.State.CONNECTED);
+            });
+
+    disposable.dispose();
   }
 }

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/LollipopNetworkObservingStrategyTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/LollipopNetworkObservingStrategyTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.verify;
   @Test public void shouldObserveConnectivity() {
     // given
     final NetworkObservingStrategy strategy = new LollipopNetworkObservingStrategy();
-    final Context context = RuntimeEnvironment.application.getApplicationContext();
+    final Context context = RuntimeEnvironment.getApplication().getApplicationContext();
 
     // when
     Connectivity connectivity = strategy.observeNetworkConnectivity(context).blockingFirst();
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.verify;
   @Test public void shouldStopObservingConnectivity() {
     // given
     final NetworkObservingStrategy strategy = new LollipopNetworkObservingStrategy();
-    final Application context = RuntimeEnvironment.application;
+    final Application context = RuntimeEnvironment.getApplication();
     final Observable<Connectivity> observable = strategy.observeNetworkConnectivity(context);
     final TestObserver<Connectivity> observer = new TestObserver<>();
 

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/MarshmallowNetworkObservingStrategyTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/MarshmallowNetworkObservingStrategyTest.java
@@ -64,12 +64,12 @@ import static org.mockito.Mockito.when;
   @Spy private Context context;
 
   @Before public void setUp() {
-    context = RuntimeEnvironment.application.getApplicationContext();
+    context = RuntimeEnvironment.getApplication().getApplicationContext();
   }
 
   @Test public void shouldObserveConnectivity() {
     // given
-    final Context context = RuntimeEnvironment.application.getApplicationContext();
+    final Context context = RuntimeEnvironment.getApplication().getApplicationContext();
 
     // when
     Connectivity connectivity = strategy.observeNetworkConnectivity(context).blockingFirst();

--- a/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/PreLollipopNetworkObservingStrategyTest.java
+++ b/library/src/test/java/com/github/pwittchen/reactivenetwork/library/rx2/network/observing/strategy/PreLollipopNetworkObservingStrategyTest.java
@@ -15,6 +15,7 @@
  */
 package com.github.pwittchen.reactivenetwork.library.rx2.network.observing.strategy;
 
+import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -22,7 +23,6 @@ import android.net.NetworkInfo;
 import com.github.pwittchen.reactivenetwork.library.rx2.Connectivity;
 import com.github.pwittchen.reactivenetwork.library.rx2.network.observing.NetworkObservingStrategy;
 import io.reactivex.Observable;
-import io.reactivex.functions.Consumer;
 import io.reactivex.observers.TestObserver;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,7 +33,6 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -50,17 +49,16 @@ import static org.mockito.Mockito.verify;
       new PreLollipopNetworkObservingStrategy();
   @Mock private BroadcastReceiver broadcastReceiver;
 
-  @Test @SuppressWarnings("CheckReturnValue") public void shouldObserveConnectivity() {
+  @SuppressLint("CheckResult") @Test @SuppressWarnings("CheckReturnValue")
+  public void shouldObserveConnectivity() {
     // given
     final NetworkObservingStrategy strategy = new PreLollipopNetworkObservingStrategy();
     final Context context = RuntimeEnvironment.application.getApplicationContext();
 
     // when
-    strategy.observeNetworkConnectivity(context).subscribe(new Consumer<Connectivity>() {
-      @Override public void accept(Connectivity connectivity) throws Exception {
-        // then
-        assertThat(connectivity.state()).isEqualTo(NetworkInfo.State.CONNECTED);
-      }
+    strategy.observeNetworkConnectivity(context).subscribe(connectivity -> {
+      // then
+      assertThat(connectivity.state()).isEqualTo(NetworkInfo.State.CONNECTED);
     });
   }
 
@@ -94,7 +92,7 @@ import static org.mockito.Mockito.verify;
   @Test public void shouldTryToUnregisterReceiver() {
     // given
     final PreLollipopNetworkObservingStrategy strategy = new PreLollipopNetworkObservingStrategy();
-    final Application context = spy(RuntimeEnvironment.application);
+    final Application context = spy(RuntimeEnvironment.getApplication());
 
     // when
     strategy.tryToUnregisterReceiver(context, broadcastReceiver);
@@ -105,7 +103,7 @@ import static org.mockito.Mockito.verify;
 
   @Test public void shouldTryToUnregisterReceiverAfterDispose() {
     // given
-    final Context context = RuntimeEnvironment.application.getApplicationContext();
+    final Context context = RuntimeEnvironment.getApplication().getApplicationContext();
     final TestObserver<Connectivity> observer = new TestObserver<>();
 
     // when


### PR DESCRIPTION
solves #467

After this update, tests works fine on Arch Linux with Android Studio Dolphin (the latest one). 
I also works fine from CLI with gradle wrapper and openjdk version "1.8.0_265".

I had problems with executing them on macOS (Macbook Air M1) with the older version Android Studio. I need to upgrade Android Studio on Mac and test it again with this change.